### PR TITLE
fix: restore native logp API parity

### DIFF
--- a/rl_engine/executors/bridge.py
+++ b/rl_engine/executors/bridge.py
@@ -2,7 +2,7 @@
 # Copyright (c) 2026 RL-Kernel Contributors
 
 import torch
-from typing import Dict, Any
+from typing import Dict, Any, cast
 from rl_engine.utils.logger import logger
 
 
@@ -55,8 +55,9 @@ class IPCWeightBridge:
         remote_weights = {}
 
         for name, info in ipc_handles.items():
-            storage = torch.cuda.FloatTensor._new_shared_cuda(info["handle"])
-            tensor = torch.cuda.FloatTensor(storage).view(info["shape"])
+            cuda_float_tensor = cast(Any, torch.cuda).FloatTensor
+            storage = cuda_float_tensor._new_shared_cuda(info["handle"])
+            tensor = cuda_float_tensor(storage).view(info["shape"])
             remote_weights[name] = tensor
 
         return remote_weights

--- a/rl_engine/kernels/ops/pytorch/loss/logp.py
+++ b/rl_engine/kernels/ops/pytorch/loss/logp.py
@@ -13,35 +13,81 @@ class NativeLogpOp:
     def __call__(self, logits: torch.Tensor, token_ids: torch.Tensor) -> torch.Tensor:
         return self.apply(logits, token_ids)
 
+    def _selected_logps(
+        self,
+        logits: torch.Tensor,
+        token_ids: torch.Tensor,
+        *,
+        output_dtype: torch.dtype,
+    ) -> torch.Tensor:
+        if logits.shape[:-1] != token_ids.shape:
+            raise ValueError(
+                f"logits leading shape {tuple(logits.shape[:-1])} must match "
+                f"token_ids shape {tuple(token_ids.shape)}"
+            )
+        logits_2d = logits.reshape(-1, logits.size(-1))
+        token_ids_1d = token_ids.reshape(-1).to(device=logits.device, dtype=torch.long)
+        log_probs = torch.nn.functional.log_softmax(logits_2d.float(), dim=-1)
+        selected_log_probs = torch.gather(log_probs, dim=-1, index=token_ids_1d.unsqueeze(1))
+        return selected_log_probs.squeeze(-1).to(output_dtype).reshape(logits.shape[:-1])
+
+    def _flat_row_indices(self, row_indices: torch.Tensor, logits: torch.Tensor) -> torch.Tensor:
+        total_rows = int(logits.numel() // logits.size(-1))
+        indices = row_indices.to(device=logits.device, dtype=torch.long).reshape(-1)
+        if indices.numel() and (indices.min().item() < 0 or indices.max().item() >= total_rows):
+            raise ValueError("row_indices contains an out-of-range row")
+        return indices
+
+    def _validate_output_shape(self, output: torch.Tensor, logits: torch.Tensor) -> None:
+        if output.shape != logits.shape[:-1]:
+            raise ValueError(
+                f"output shape {tuple(output.shape)} must match logits leading shape "
+                f"{tuple(logits.shape[:-1])}"
+            )
+
     def apply(self, logits: torch.Tensor, token_ids: torch.Tensor) -> torch.Tensor:
-        """Baseline cross-entropy log prob extraction using torch.gather."""
-        orig_shape = logits.shape[:-1]
-        logits_2d = logits.view(-1, logits.size(-1))
-        token_ids_1d = token_ids.view(-1).unsqueeze(1)
-        log_probs = torch.nn.functional.log_softmax(logits_2d.float(), dim=-1).to(logits.dtype)
-        selected_log_probs = torch.gather(log_probs, dim=-1, index=token_ids_1d.long()).squeeze(-1)
-        return selected_log_probs.view(orig_shape)
+        """Baseline selected-token log probability extraction using torch.gather."""
+        return self._selected_logps(logits, token_ids, output_dtype=logits.dtype)
 
     def apply_fp32(self, logits: torch.Tensor, token_ids: torch.Tensor) -> torch.Tensor:
         """Same as apply but forces float32 output for numerical stability."""
-        logits_fp32 = logits.float()
-        return self.apply(logits_fp32, token_ids)
+        return self._selected_logps(logits, token_ids, output_dtype=torch.float32)
+
+    def indexed_out(
+        self,
+        logits: torch.Tensor,
+        token_ids: torch.Tensor,
+        row_indices: torch.Tensor,
+        output: torch.Tensor,
+    ) -> torch.Tensor:
+        self._validate_output_shape(output, logits)
+        indices = self._flat_row_indices(row_indices, logits)
+        values = self._selected_logps(logits, token_ids, output_dtype=output.dtype)
+        output.reshape(-1)[indices] = values.reshape(-1)[indices]
+        return output
 
     def indexed_fp32(
         self, logits: torch.Tensor, token_ids: torch.Tensor, row_indices: torch.Tensor
     ) -> torch.Tensor:
-        orig_shape = logits.shape[:-1]
-        logits_2d = logits.view(-1, logits.size(-1))
-        token_ids_1d = token_ids.view(-1)
-        valid_logits = logits_2d[row_indices]
-        valid_token_ids = token_ids_1d[row_indices]
-        valid_log_probs = self.apply_fp32(valid_logits.unsqueeze(0), valid_token_ids.unsqueeze(0))
-        output = torch.zeros(orig_shape, device=logits.device, dtype=torch.float32).view(-1)
-        output[row_indices] = valid_log_probs.view(-1)
-        return output.view(orig_shape)
+        output = torch.zeros(logits.shape[:-1], device=logits.device, dtype=torch.float32)
+        return self.indexed_out(logits, token_ids, row_indices, output)
+
+    def online_out(
+        self, logits: torch.Tensor, token_ids: torch.Tensor, output: torch.Tensor
+    ) -> torch.Tensor:
+        return self.out(logits, token_ids, output)
 
     def online_fp32(self, logits: torch.Tensor, token_ids: torch.Tensor) -> torch.Tensor:
         return self.apply_fp32(logits, token_ids)
+
+    def online_indexed_out(
+        self,
+        logits: torch.Tensor,
+        token_ids: torch.Tensor,
+        row_indices: torch.Tensor,
+        output: torch.Tensor,
+    ) -> torch.Tensor:
+        return self.indexed_out(logits, token_ids, row_indices, output)
 
     def online_indexed_fp32(
         self, logits: torch.Tensor, token_ids: torch.Tensor, row_indices: torch.Tensor
@@ -51,6 +97,7 @@ class NativeLogpOp:
     def out(
         self, logits: torch.Tensor, token_ids: torch.Tensor, output: torch.Tensor
     ) -> torch.Tensor:
-        result = self.apply(logits, token_ids)
+        self._validate_output_shape(output, logits)
+        result = self._selected_logps(logits, token_ids, output_dtype=output.dtype)
         output.copy_(result)
         return output

--- a/tests/test_op_accuracy.py
+++ b/tests/test_op_accuracy.py
@@ -3,6 +3,7 @@
 
 import pytest
 import torch
+from rl_engine.kernels.ops.pytorch.loss.logp import NativeLogpOp
 from rl_engine.kernels.registry import kernel_registry
 from rl_engine.platforms.device import device_ctx
 from rl_engine.utils.logger import logger
@@ -10,6 +11,111 @@ from rl_engine.utils.logger import logger
 
 def _fused_logp_op(op_type: str = "logp"):
     return kernel_registry.get_op(op_type)
+
+
+def _reference_selected_logp(logits: torch.Tensor, token_ids: torch.Tensor) -> torch.Tensor:
+    ref_logp = torch.log_softmax(logits.float(), dim=-1)
+    return torch.gather(ref_logp, dim=-1, index=token_ids.long().unsqueeze(-1)).squeeze(-1)
+
+
+def test_native_logp_op_exposes_full_fused_logp_api():
+    op = NativeLogpOp()
+
+    for method_name in (
+        "apply",
+        "out",
+        "apply_fp32",
+        "indexed_out",
+        "indexed_fp32",
+        "online_out",
+        "online_fp32",
+        "online_indexed_out",
+        "online_indexed_fp32",
+    ):
+        assert callable(getattr(op, method_name))
+
+
+def test_native_fused_logp_out_reuses_output_storage_cpu():
+    logits = torch.randn(2, 3, 17)
+    token_ids = torch.randint(0, logits.size(-1), (2, 3))
+    output = torch.empty(logits.shape[:-1])
+
+    result = NativeLogpOp().out(logits, token_ids, output)
+
+    assert result is output
+    assert result.data_ptr() == output.data_ptr()
+    assert torch.allclose(result, _reference_selected_logp(logits, token_ids))
+
+
+def test_native_fused_logp_indexed_out_preserves_inactive_rows_cpu():
+    logits = torch.randn(3, 4, 19)
+    token_ids = torch.randint(0, logits.size(-1), (3, 4))
+    mask = torch.zeros((3, 4), dtype=torch.bool)
+    mask[0, 1] = True
+    mask[1, 3] = True
+    mask[2, 0] = True
+    row_indices = mask.reshape(-1).nonzero(as_tuple=False).squeeze(-1)
+    output = torch.full(logits.shape[:-1], 123.0)
+
+    result = NativeLogpOp().indexed_out(logits, token_ids, row_indices, output)
+    ref_logp = _reference_selected_logp(logits, token_ids)
+
+    assert result is output
+    assert result.data_ptr() == output.data_ptr()
+    assert torch.allclose(result[mask], ref_logp[mask])
+    assert torch.equal(result[~mask], torch.full_like(result[~mask], 123.0))
+
+
+def test_native_fused_logp_online_out_matches_reference_cpu():
+    logits = torch.randn(2, 5, 23)
+    token_ids = torch.randint(0, logits.size(-1), (2, 5))
+    output = torch.empty(logits.shape[:-1])
+
+    result = NativeLogpOp().online_out(logits, token_ids, output)
+
+    assert result is output
+    assert torch.allclose(result, _reference_selected_logp(logits, token_ids))
+
+
+def test_native_fused_logp_online_indexed_out_preserves_inactive_rows_cpu():
+    logits = torch.randn(2, 6, 29)
+    token_ids = torch.randint(0, logits.size(-1), (2, 6))
+    mask = torch.zeros((2, 6), dtype=torch.bool)
+    mask[:, 1::2] = True
+    row_indices = mask.reshape(-1).nonzero(as_tuple=False).squeeze(-1)
+    output = torch.full(logits.shape[:-1], -77.0)
+
+    result = NativeLogpOp().online_indexed_out(logits, token_ids, row_indices, output)
+    ref_logp = _reference_selected_logp(logits, token_ids)
+
+    assert result is output
+    assert torch.allclose(result[mask], ref_logp[mask])
+    assert torch.equal(result[~mask], torch.full_like(result[~mask], -77.0))
+
+
+@pytest.mark.parametrize("method_name", ("indexed_fp32", "online_indexed_fp32"))
+def test_native_fused_logp_indexed_fp32_zero_fills_inactive_rows_cpu(method_name: str):
+    logits = torch.randn(2, 5, 31)
+    token_ids = torch.randint(0, logits.size(-1), (2, 5))
+    mask = torch.zeros((2, 5), dtype=torch.bool)
+    mask[:, ::2] = True
+    row_indices = mask.reshape(-1).nonzero(as_tuple=False).squeeze(-1)
+
+    result = getattr(NativeLogpOp(), method_name)(logits, token_ids, row_indices)
+    ref_logp = _reference_selected_logp(logits, token_ids)
+
+    assert result.dtype == torch.float32
+    assert torch.allclose(result[mask], ref_logp[mask])
+    assert torch.equal(result[~mask], torch.zeros_like(result[~mask]))
+
+
+def test_native_fused_logp_rejects_out_of_range_row_indices_cpu():
+    logits = torch.randn(2, 3, 11)
+    token_ids = torch.randint(0, logits.size(-1), (2, 3))
+    output = torch.empty(logits.shape[:-1])
+
+    with pytest.raises(ValueError, match="out-of-range"):
+        NativeLogpOp().indexed_out(logits, token_ids, torch.tensor([0, 6]), output)
 
 
 def test_accuracy():


### PR DESCRIPTION
## Summary

- Restores native/PyTorch `NativeLogpOp` fused-logp API parity for indexed and online variants.
- Adds direct CPU/native tests so fallback parity is validated without relying on CUDA dispatch.
- Fixes an existing mypy issue in the CUDA IPC bridge by casting dynamic `torch.cuda.FloatTensor` access.

## Issue

Closes #55.

## Details

`tests/test_op_accuracy.py` exercises fused-logp indexed and online variants through the public operator API:

- `indexed_out(...)`
- `online_out(...)`
- `online_indexed_out(...)`

The CUDA implementation already exposes these methods, but the native fallback on `main` only had the fp32 indexed/online helpers and dense `out(...)`. When CUDA fused-logp is unavailable and the registry falls back to `NativeLogpOp`, these calls can fail with `AttributeError`.

This PR makes `NativeLogpOp` a faithful reference fallback for the public fused-logp API:

- `apply`
- `out`
- `apply_fp32`
- `indexed_out`
- `indexed_fp32`
- `online_out`
- `online_fp32`
- `online_indexed_out`
- `online_indexed_fp32`

The out APIs reuse caller-provided output storage. Indexed out APIs only update flattened `row_indices` and preserve inactive rows. Indexed fp32 helper APIs return dense float32 outputs with inactive rows zero-filled.

## Validation

- `pre-commit run --all-files`: passed
- `mypy --ignore-missing-imports rl_engine/`: passed
- `py -3.13 -m pytest tests\test_op_accuracy.py -q`: passed, 16 tests
- `py -3.13 -m pytest rl_engine\tests\test_dispatch.py -v`: passed, 3 tests
- `py -3.13 -m pytest tests\test_op_accuracy.py rl_engine\tests\test_dispatch.py -q`: passed, 19 tests
- `py -3.13 -m compileall rl_engine tests benchmarks`: passed
- `py -3.13 -m mkdocs build --strict -f mkdocs.yaml`: passed

## DCO

Committed with `git commit -s`.