### PR TITLE
feat: add SM90 linear logp backward fast paths

### DIFF
--- a/csrc/cuda/fused_linear_logp_sm90.cu
+++ b/csrc/cuda/fused_linear_logp_sm90.cu
@@ -6,12 +6,19 @@
 
 #include "../utils/tma_utils.cuh"
 #include <ATen/cuda/CUDAContext.h>
+#include <c10/cuda/CUDAGuard.h>
 #include <algorithm>
+#include <cctype>
+#include <cstdlib>
 #include <cuda_bf16.h>
 #include <math_constants.h>
+#include <mma.h>
+#include <string>
 #include <torch/extension.h>
 
 namespace {
+
+namespace wmma = nvcuda::wmma;
 
 constexpr int BM = 256;       // tokens per CTA
 constexpr int BN = 64;        // vocab per tile
@@ -30,8 +37,29 @@ constexpr int N_TILES = BN / MMA_N;      // 8 n-tiles per warp
 constexpr int K_TILES = BK / MMA_K;      // MMA k-steps per TMA tile
 constexpr int KK_GROUPS = BK / 32;       // 32-wide ldmatrix.x4 groups (2 k-steps each)
 
+constexpr int STREAM_BWD_THREADS = 256;
+constexpr int STREAM_BWD_VECS = 4;
+constexpr int STREAM_BWD_MAX_D = 4096;
+constexpr int STREAM_BWD_MAX_SLOTS = STREAM_BWD_MAX_D / STREAM_BWD_THREADS;
+
+constexpr int LOGITS_WMMA_M = 16;
+constexpr int LOGITS_WMMA_N = 16;
+constexpr int LOGITS_WMMA_K = 8;
+constexpr int LOGITS_WMMA_WARPS = 4;
+constexpr int LOGITS_WMMA_THREADS = LOGITS_WMMA_WARPS * 32;
+
+constexpr int GRAD_W_WMMA_M = 16;
+constexpr int GRAD_W_WMMA_N = 16;
+constexpr int GRAD_W_WMMA_K = 16;
+constexpr int GRAD_W_WMMA_WARPS = 8;
+constexpr int GRAD_W_WMMA_THREADS = GRAD_W_WMMA_WARPS * 32;
+
 static_assert(WARP_M % MMA_M == 0, "rows per warp must be a multiple of MMA_M");
 static_assert(BK % 32 == 0, "BK must be a multiple of 32 (ldmatrix.x4 spans 32 cols)");
+
+inline void init_tensor_map_noswizzle(CUtensorMap *tmap, const nv_bfloat16 *gmem,
+                                      uint64_t gmem_height, uint64_t gmem_width,
+                                      uint32_t box_height, uint32_t box_width);
 
 // Tensor-core helpers (Ampere/Hopper warp-level MMA). Same layout as
 // prefix_shared_attention.cu, validated on this repo's Hopper GPUs.
@@ -51,7 +79,6 @@ __device__ __forceinline__ void mma_m16n8k16(const uint32_t A[4], const uint32_t
                    "f"(D[0]), "f"(D[1]), "f"(D[2]), "f"(D[3]));
 }
 
-
 __global__ void fused_linear_logp_sm90_kernel(const __grid_constant__ CUtensorMap h_tmap,
                                               const __grid_constant__ CUtensorMap w_tmap,
                                               const int *__restrict__ target,
@@ -59,7 +86,8 @@ __global__ void fused_linear_logp_sm90_kernel(const __grid_constant__ CUtensorMa
                                               float *__restrict__ part_max,   // [n_split, N]
                                               float *__restrict__ part_sum,   // [n_split, N]
                                               float *__restrict__ part_zt,    // [n_split, N]
-                                              int N, int D, int V, int n_split) {
+                                              int N, int D, int V, int n_split,
+                                              int vocab_start_index) {
     const int tid = threadIdx.x;
     const int warp = tid / 32;
     const int lane = tid % 32;
@@ -219,7 +247,7 @@ __global__ void fused_linear_logp_sm90_kernel(const __grid_constant__ CUtensorMa
                 if (bias != nullptr)
                     val += bias[col];
                 tmax = fmaxf(tmax, val);
-                if (col == tgt)
+                if (vocab_start_index + col == tgt)
                     sZt[r] = val;
             }
             float tsum = 0.0f;
@@ -250,15 +278,172 @@ __global__ void fused_linear_logp_sm90_kernel(const __grid_constant__ CUtensorMa
     }
 }
 
+__global__ void fused_linear_logp_logits_tile_bf16_mma_kernel(
+    const __grid_constant__ CUtensorMap h_tmap,
+    const __grid_constant__ CUtensorMap w_tmap,
+    float *__restrict__ logits,
+    nv_bfloat16 *__restrict__ dlogits_bf16,
+    const int *__restrict__ target,
+    const float *__restrict__ grad_logp,
+    const float *__restrict__ lse,
+    int N,
+    int D,
+    int V,
+    int64_t logits_stride0,
+    int64_t dlogits_stride0,
+    int vocab_start_index,
+    bool write_dlogits) {
+    const int tid = threadIdx.x;
+    const int warp = tid / 32;
+    const int lane = tid % 32;
+    const int row_block = blockIdx.x;
+    const int vt = blockIdx.y;
+    const int row_base = row_block * BM;
+    const int col_base = vt * BN;
+    const int num_rows = min(BM, N - row_base);
+    const int kd = D / BK;
+
+    extern __shared__ __align__(1024) char smem[];
+    nv_bfloat16 *sH = reinterpret_cast<nv_bfloat16 *>(smem);
+    nv_bfloat16 *sW = reinterpret_cast<nv_bfloat16 *>(sH + STAGES * BM * BK);
+    float *sLogits = reinterpret_cast<float *>(sW + STAGES * BN * BK);
+    int *mbar_base = reinterpret_cast<int *>(sLogits + BM * BN);
+
+    const uint64_t sH_base_tma = __cvta_generic_to_shared(sH);
+    const uint64_t sW_base_tma = __cvta_generic_to_shared(sW);
+    const uint32_t sH_base = static_cast<uint32_t>(sH_base_tma);
+    const uint32_t sW_base = static_cast<uint32_t>(sW_base_tma);
+    uint64_t mbar[STAGES];
+#pragma unroll
+    for (int s = 0; s < STAGES; ++s)
+        mbar[s] = __cvta_generic_to_shared(mbar_base + 2 * s);
+
+    if (tid == 0) {
+#pragma unroll
+        for (int s = 0; s < STAGES; ++s)
+            mbarrier_init(mbar[s], 1);
+        asm volatile("fence.mbarrier_init.release.cluster;");
+    }
+    __syncthreads();
+
+    const uint32_t tile_bytes = (BM * BK + BN * BK) * sizeof(nv_bfloat16);
+    auto issue_load = [&](int k) {
+        const int buf = k % STAGES;
+        const int k_off = k * BK;
+        mbarrier_arrive_expect_tx(mbar[buf], tile_bytes);
+        tma_2d_g2s(sH_base_tma + buf * BM * BK * sizeof(nv_bfloat16), &h_tmap, k_off, row_base,
+                   mbar[buf]);
+        tma_2d_g2s(sW_base_tma + buf * BN * BK * sizeof(nv_bfloat16), &w_tmap, k_off, col_base,
+                   mbar[buf]);
+    };
+
+    int phase[STAGES];
+#pragma unroll
+    for (int s = 0; s < STAGES; ++s)
+        phase[s] = 0;
+
+    float acc[M_TILES][N_TILES][4];
+#pragma unroll
+    for (int mi = 0; mi < M_TILES; ++mi)
+#pragma unroll
+        for (int n = 0; n < N_TILES; ++n)
+            acc[mi][n][0] = acc[mi][n][1] = acc[mi][n][2] = acc[mi][n][3] = 0.0f;
+
+    if (tid == 0) {
+#pragma unroll
+        for (int s = 0; s < STAGES - 1; ++s)
+            if (s < kd)
+                issue_load(s);
+    }
+    for (int k = 0; k < kd; ++k) {
+        const int buf = k % STAGES;
+        if (tid == 0 && k + (STAGES - 1) < kd)
+            issue_load(k + (STAGES - 1));
+        mbarrier_wait(mbar[buf], phase[buf]);
+        phase[buf] ^= 1;
+        __syncthreads();
+
+        const uint32_t sH_buf = sH_base + buf * BM * BK * sizeof(nv_bfloat16);
+        const uint32_t sW_buf = sW_base + buf * BN * BK * sizeof(nv_bfloat16);
+
+        uint32_t A[M_TILES][K_TILES][4];
+#pragma unroll
+        for (int mi = 0; mi < M_TILES; ++mi) {
+            const int row0 = warp * WARP_M + mi * MMA_M + (lane % 16);
+#pragma unroll
+            for (int kt = 0; kt < K_TILES; ++kt) {
+                const uint32_t a_addr =
+                    sH_buf + (row0 * BK + (lane / 16) * 8 + kt * MMA_K) * sizeof(nv_bfloat16);
+                ldmatrix_x4(A[mi][kt], a_addr);
+            }
+        }
+
+#pragma unroll
+        for (int n = 0; n < N_TILES; ++n) {
+#pragma unroll
+            for (int kk = 0; kk < KK_GROUPS; ++kk) {
+                uint32_t b4[4];
+                const uint32_t b_addr =
+                    sW_buf + ((n * MMA_N + (lane % 8)) * BK + (lane / 8) * 8 + kk * 32) *
+                                 sizeof(nv_bfloat16);
+                ldmatrix_x4(b4, b_addr);
+                const uint32_t B0[2] = {b4[0], b4[1]};
+                const uint32_t B1[2] = {b4[2], b4[3]};
+#pragma unroll
+                for (int mi = 0; mi < M_TILES; ++mi) {
+                    mma_m16n8k16(A[mi][2 * kk + 0], B0, acc[mi][n]);
+                    mma_m16n8k16(A[mi][2 * kk + 1], B1, acc[mi][n]);
+                }
+            }
+        }
+        __syncthreads();
+    }
+
+#pragma unroll
+    for (int mi = 0; mi < M_TILES; ++mi) {
+        const int row = warp * WARP_M + mi * MMA_M + lane / 4;
+#pragma unroll
+        for (int n = 0; n < N_TILES; ++n) {
+            const int col = n * MMA_N + (lane % 4) * 2;
+            sLogits[row * BN + col + 0] = acc[mi][n][0];
+            sLogits[row * BN + col + 1] = acc[mi][n][1];
+            sLogits[(row + 8) * BN + col + 0] = acc[mi][n][2];
+            sLogits[(row + 8) * BN + col + 1] = acc[mi][n][3];
+        }
+    }
+    __syncthreads();
+
+    for (int idx = tid; idx < num_rows * BN; idx += WG_THREADS) {
+        const int r = idx / BN;
+        const int c = idx - r * BN;
+        const int col = col_base + c;
+        const int global_row = row_base + r;
+        if (col < V) {
+            const float logit = sLogits[r * BN + c];
+            if (write_dlogits) {
+                const int global_col = vocab_start_index + col;
+                float dz = -__expf(logit - lse[global_row]);
+                if (target[global_row] == global_col)
+                    dz += 1.0f;
+                dlogits_bf16[(static_cast<int64_t>(global_row) * dlogits_stride0) + col] =
+                    __float2bfloat16(dz * grad_logp[global_row]);
+            } else {
+                logits[(static_cast<int64_t>(global_row) * logits_stride0) + col] = logit;
+            }
+        }
+    }
+}
+
 // Merge per-split partials: M = max_s m_s, S = sum_s s_s*exp(m_s - M),
 // zt = sum_s zt_s (exactly one split holds the target column), then
 // logp = zt - (M + log S). One thread per token row.
 __global__ void fused_linear_logp_sm90_combine_kernel(const float *__restrict__ part_max,
                                                       const float *__restrict__ part_sum,
                                                       const float *__restrict__ part_zt,
-                                                      float *__restrict__ out_logp,
+                                                      float *__restrict__ out_value,
                                                       float *__restrict__ out_lse, int N,
-                                                      int n_split) {
+                                                      int n_split,
+                                                      bool return_target_logit) {
     const int r = blockIdx.x * blockDim.x + threadIdx.x;
     if (r >= N)
         return;
@@ -275,8 +460,1243 @@ __global__ void fused_linear_logp_sm90_combine_kernel(const float *__restrict__ 
         zt += part_zt[idx];
     }
     const float lse = M + logf(S);
-    out_logp[r] = zt - lse;
+    out_value[r] = return_target_logit ? zt : zt - lse;
     out_lse[r] = lse;
+}
+
+__global__ void fused_linear_logp_backward_dlogits_kernel(float *__restrict__ logits,
+                                                          const int *__restrict__ target,
+                                                          const float *__restrict__ grad_logp,
+                                                          const float *__restrict__ lse, int N,
+                                                          int V, int vocab_start_index,
+                                                          bool logits_are_probs) {
+    const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    const int64_t total = static_cast<int64_t>(N) * V;
+    if (idx >= total)
+        return;
+
+    const int row = static_cast<int>(idx / V);
+    const int local_col = static_cast<int>(idx - static_cast<int64_t>(row) * V);
+    const int global_col = vocab_start_index + local_col;
+    float dz = logits_are_probs ? -logits[idx] : -__expf(logits[idx] - lse[row]);
+    if (target[row] == global_col)
+        dz += 1.0f;
+    logits[idx] = dz * grad_logp[row];
+}
+
+__global__ void fused_linear_logp_backward_dlogits_row_kernel(float *__restrict__ logits,
+                                                              const int *__restrict__ target,
+                                                              const float *__restrict__ grad_logp,
+                                                              const float *__restrict__ lse,
+                                                              int N,
+                                                              int V,
+                                                              int vocab_start_index,
+                                                              bool logits_are_probs) {
+    const int row = blockIdx.x;
+    const int tid = threadIdx.x;
+    if (row >= N)
+        return;
+
+    __shared__ float row_lse;
+    __shared__ float row_grad;
+    __shared__ int target_local;
+    if (tid == 0) {
+        row_lse = lse[row];
+        row_grad = grad_logp[row];
+        target_local = target[row] - vocab_start_index;
+    }
+    __syncthreads();
+
+    const int64_t row_offset = static_cast<int64_t>(row) * V;
+    for (int col = tid; col < V; col += blockDim.x) {
+        const int64_t offset = row_offset + col;
+        float dz = logits_are_probs ? -logits[offset] : -__expf(logits[offset] - row_lse);
+        if (col == target_local)
+            dz += 1.0f;
+        logits[offset] = dz * row_grad;
+    }
+}
+
+__global__ void fused_linear_logp_backward_dlogits_bf16_kernel(
+    const float *__restrict__ logits_or_probs,
+    nv_bfloat16 *__restrict__ dlogits_bf16,
+    const int *__restrict__ target,
+    const float *__restrict__ grad_logp,
+    const float *__restrict__ lse,
+    int N,
+    int V,
+    int64_t logits_stride0,
+    int64_t dlogits_stride0,
+    int vocab_start_index,
+    bool logits_are_probs) {
+    const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    const int64_t total = static_cast<int64_t>(N) * V;
+    if (idx >= total)
+        return;
+
+    const int row = static_cast<int>(idx / V);
+    const int local_col = static_cast<int>(idx - static_cast<int64_t>(row) * V);
+    const int global_col = vocab_start_index + local_col;
+    const int64_t logits_idx = static_cast<int64_t>(row) * logits_stride0 + local_col;
+    const int64_t dlogits_idx = static_cast<int64_t>(row) * dlogits_stride0 + local_col;
+    float dz = logits_are_probs ? -logits_or_probs[logits_idx]
+                                : -__expf(logits_or_probs[logits_idx] - lse[row]);
+    if (target[row] == global_col)
+        dz += 1.0f;
+    dlogits_bf16[dlogits_idx] = __float2bfloat16(dz * grad_logp[row]);
+}
+
+__global__ void fused_linear_logp_backward_dlogits_bf16_row_kernel(
+    const float *__restrict__ logits_or_probs,
+    nv_bfloat16 *__restrict__ dlogits_bf16,
+    const int *__restrict__ target,
+    const float *__restrict__ grad_logp,
+    const float *__restrict__ lse,
+    int N,
+    int V,
+    int64_t logits_stride0,
+    int64_t dlogits_stride0,
+    int vocab_start_index,
+    bool logits_are_probs) {
+    const int row = blockIdx.x;
+    const int tid = threadIdx.x;
+    if (row >= N)
+        return;
+
+    __shared__ float row_lse;
+    __shared__ float row_grad;
+    __shared__ int target_local;
+    if (tid == 0) {
+        row_lse = lse[row];
+        row_grad = grad_logp[row];
+        target_local = target[row] - vocab_start_index;
+    }
+    __syncthreads();
+
+    const int64_t logits_row_offset = static_cast<int64_t>(row) * logits_stride0;
+    const int64_t dlogits_row_offset = static_cast<int64_t>(row) * dlogits_stride0;
+    for (int col = tid; col < V; col += blockDim.x) {
+        const int64_t logits_idx = logits_row_offset + col;
+        const int64_t dlogits_idx = dlogits_row_offset + col;
+        float dz = logits_are_probs ? -logits_or_probs[logits_idx]
+                                    : -__expf(logits_or_probs[logits_idx] - row_lse);
+        if (col == target_local)
+            dz += 1.0f;
+        dlogits_bf16[dlogits_idx] = __float2bfloat16(dz * row_grad);
+    }
+}
+
+__global__ void linear_logp_probs_bf16_forward_kernel(
+    const nv_bfloat16 *__restrict__ logits,
+    const int *__restrict__ target,
+    float *__restrict__ out_logp,
+    float *__restrict__ out_target_logit,
+    float *__restrict__ out_lse,
+    nv_bfloat16 *__restrict__ probs,
+    int N,
+    int V,
+    int64_t logits_stride0,
+    int64_t probs_stride0,
+    int vocab_start_index) {
+    constexpr int THREADS = 256;
+    __shared__ float reduce[THREADS];
+    __shared__ float row_max_shared;
+    __shared__ float row_sum_shared;
+    __shared__ float target_logit_shared;
+
+    const int row = blockIdx.x;
+    const int tid = threadIdx.x;
+    if (row >= N)
+        return;
+
+    const int tgt = target[row] - vocab_start_index;
+    float local_max = -CUDART_INF_F;
+    float local_target = 0.0f;
+    for (int col = tid; col < V; col += blockDim.x) {
+        const float val =
+            __bfloat162float(logits[static_cast<int64_t>(row) * logits_stride0 + col]);
+        local_max = fmaxf(local_max, val);
+        if (col == tgt)
+            local_target = val;
+    }
+    reduce[tid] = local_max;
+    __syncthreads();
+    for (int offset = blockDim.x / 2; offset > 0; offset >>= 1) {
+        if (tid < offset)
+            reduce[tid] = fmaxf(reduce[tid], reduce[tid + offset]);
+        __syncthreads();
+    }
+    if (tid == 0) {
+        row_max_shared = reduce[0];
+        target_logit_shared = local_target;
+    }
+    __syncthreads();
+    if (tid != 0 && tgt >= 0 && tgt < V && (tgt % blockDim.x) == tid) {
+        target_logit_shared =
+            __bfloat162float(logits[static_cast<int64_t>(row) * logits_stride0 + tgt]);
+    }
+    __syncthreads();
+
+    const float row_max = row_max_shared;
+    float local_sum = 0.0f;
+    for (int col = tid; col < V; col += blockDim.x) {
+        const float val =
+            __bfloat162float(logits[static_cast<int64_t>(row) * logits_stride0 + col]);
+        local_sum += __expf(val - row_max);
+    }
+    reduce[tid] = local_sum;
+    __syncthreads();
+    for (int offset = blockDim.x / 2; offset > 0; offset >>= 1) {
+        if (tid < offset)
+            reduce[tid] += reduce[tid + offset];
+        __syncthreads();
+    }
+    if (tid == 0)
+        row_sum_shared = reduce[0];
+    __syncthreads();
+
+    if (probs != nullptr) {
+        const float inv_sum = 1.0f / row_sum_shared;
+        for (int col = tid; col < V; col += blockDim.x) {
+            const float val =
+                __bfloat162float(logits[static_cast<int64_t>(row) * logits_stride0 + col]);
+            probs[static_cast<int64_t>(row) * probs_stride0 + col] =
+                __float2bfloat16(__expf(val - row_max) * inv_sum);
+        }
+    }
+    if (tid == 0) {
+        const float lse = row_max + logf(row_sum_shared);
+        if (out_logp != nullptr)
+            out_logp[row] = target_logit_shared - lse;
+        if (out_target_logit != nullptr)
+            out_target_logit[row] = target_logit_shared;
+        if (out_lse != nullptr)
+            out_lse[row] = lse;
+    }
+}
+
+__global__ void linear_logp_probs_bf16_to_dlogits_kernel(nv_bfloat16 *__restrict__ probs,
+                                                         const int *__restrict__ target,
+                                                         const float *__restrict__ grad_logp,
+                                                         int N,
+                                                         int V,
+                                                         int64_t probs_stride0,
+                                                         int vocab_start_index) {
+    const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    const int64_t total = static_cast<int64_t>(N) * V;
+    if (idx >= total)
+        return;
+    const int row = static_cast<int>(idx / V);
+    const int col = static_cast<int>(idx - static_cast<int64_t>(row) * V);
+    const int64_t offset = static_cast<int64_t>(row) * probs_stride0 + col;
+    float dz = -__bfloat162float(probs[offset]);
+    if (target[row] == vocab_start_index + col)
+        dz += 1.0f;
+    probs[offset] = __float2bfloat16(dz * grad_logp[row]);
+}
+
+__global__ void linear_logp_local_probs_bf16_to_dlogits_kernel(
+    nv_bfloat16 *__restrict__ probs,
+    const int *__restrict__ target,
+    const float *__restrict__ grad_logp,
+    const float *__restrict__ local_lse,
+    const float *__restrict__ global_lse,
+    int N,
+    int V,
+    int64_t probs_stride0,
+    int vocab_start_index) {
+    const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    const int64_t total = static_cast<int64_t>(N) * V;
+    if (idx >= total)
+        return;
+    const int row = static_cast<int>(idx / V);
+    const int col = static_cast<int>(idx - static_cast<int64_t>(row) * V);
+    const int64_t offset = static_cast<int64_t>(row) * probs_stride0 + col;
+    const float local_to_global = __expf(local_lse[row] - global_lse[row]);
+    float dz = -__bfloat162float(probs[offset]) * local_to_global;
+    if (target[row] == vocab_start_index + col)
+        dz += 1.0f;
+    probs[offset] = __float2bfloat16(dz * grad_logp[row]);
+}
+
+__global__ void linear_logp_local_probs_bf16_to_dlogits_row_kernel(
+    nv_bfloat16 *__restrict__ probs,
+    const int *__restrict__ target,
+    const float *__restrict__ grad_logp,
+    const float *__restrict__ local_lse,
+    const float *__restrict__ global_lse,
+    int N,
+    int V,
+    int64_t probs_stride0,
+    int vocab_start_index) {
+    const int row = blockIdx.x;
+    const int tid = threadIdx.x;
+    if (row >= N)
+        return;
+
+    __shared__ float local_to_global;
+    __shared__ float row_grad;
+    __shared__ int target_local;
+    if (tid == 0) {
+        local_to_global = __expf(local_lse[row] - global_lse[row]);
+        row_grad = grad_logp[row];
+        target_local = target[row] - vocab_start_index;
+    }
+    __syncthreads();
+
+    const int64_t row_offset = static_cast<int64_t>(row) * probs_stride0;
+    for (int col = tid; col < V; col += blockDim.x) {
+        const int64_t offset = row_offset + col;
+        float dz = -__bfloat162float(probs[offset]) * local_to_global;
+        if (col == target_local)
+            dz += 1.0f;
+        probs[offset] = __float2bfloat16(dz * row_grad);
+    }
+}
+
+__global__ void linear_logp_logits_bf16_to_dlogits_kernel(
+    const nv_bfloat16 *__restrict__ logits,
+    nv_bfloat16 *__restrict__ dlogits,
+    const int *__restrict__ target,
+    const float *__restrict__ grad_logp,
+    const float *__restrict__ lse,
+    int N,
+    int V,
+    int64_t logits_stride0,
+    int64_t dlogits_stride0,
+    int vocab_start_index) {
+    const int64_t idx = static_cast<int64_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+    const int64_t total = static_cast<int64_t>(N) * V;
+    if (idx >= total)
+        return;
+    const int row = static_cast<int>(idx / V);
+    const int col = static_cast<int>(idx - static_cast<int64_t>(row) * V);
+    const float logit =
+        __bfloat162float(logits[static_cast<int64_t>(row) * logits_stride0 + col]);
+    float dz = -__expf(logit - lse[row]);
+    if (target[row] == vocab_start_index + col)
+        dz += 1.0f;
+    dlogits[static_cast<int64_t>(row) * dlogits_stride0 + col] =
+        __float2bfloat16(dz * grad_logp[row]);
+}
+
+__global__ void linear_logp_logits_bf16_to_dlogits_row_kernel(
+    const nv_bfloat16 *__restrict__ logits,
+    nv_bfloat16 *__restrict__ dlogits,
+    const int *__restrict__ target,
+    const float *__restrict__ grad_logp,
+    const float *__restrict__ lse,
+    int N,
+    int V,
+    int64_t logits_stride0,
+    int64_t dlogits_stride0,
+    int vocab_start_index) {
+    const int row = blockIdx.x;
+    const int tid = threadIdx.x;
+    if (row >= N)
+        return;
+
+    __shared__ float row_lse;
+    __shared__ float row_grad;
+    __shared__ int target_local;
+    if (tid == 0) {
+        row_lse = lse[row];
+        row_grad = grad_logp[row];
+        target_local = target[row] - vocab_start_index;
+    }
+    __syncthreads();
+
+    const int64_t logits_row_offset = static_cast<int64_t>(row) * logits_stride0;
+    const int64_t dlogits_row_offset = static_cast<int64_t>(row) * dlogits_stride0;
+    for (int col = tid; col < V; col += blockDim.x) {
+        const float logit = __bfloat162float(logits[logits_row_offset + col]);
+        float dz = -__expf(logit - row_lse);
+        if (col == target_local)
+            dz += 1.0f;
+        dlogits[dlogits_row_offset + col] = __float2bfloat16(dz * row_grad);
+    }
+}
+
+__global__ void fused_linear_logp_logits_tile_tf32_wmma_kernel(
+    const float *__restrict__ hidden,
+    const float *__restrict__ weight,
+    float *__restrict__ logits,
+    int N,
+    int D,
+    int V,
+    int64_t logits_stride0) {
+    const int warp_in_block = threadIdx.x / 32;
+    const int tile_idx = blockIdx.x * LOGITS_WMMA_WARPS + warp_in_block;
+    const int tiles_n = V / LOGITS_WMMA_N;
+    const int total_tiles = (N / LOGITS_WMMA_M) * tiles_n;
+    if (tile_idx >= total_tiles)
+        return;
+
+    const int row_tile = tile_idx / tiles_n;
+    const int col_tile = tile_idx - row_tile * tiles_n;
+    const int row0 = row_tile * LOGITS_WMMA_M;
+    const int col0 = col_tile * LOGITS_WMMA_N;
+
+    wmma::fragment<wmma::matrix_a, LOGITS_WMMA_M, LOGITS_WMMA_N, LOGITS_WMMA_K,
+                   wmma::precision::tf32, wmma::row_major>
+        a_frag;
+    wmma::fragment<wmma::matrix_b, LOGITS_WMMA_M, LOGITS_WMMA_N, LOGITS_WMMA_K,
+                   wmma::precision::tf32, wmma::col_major>
+        b_frag;
+    wmma::fragment<wmma::accumulator, LOGITS_WMMA_M, LOGITS_WMMA_N, LOGITS_WMMA_K, float>
+        acc_frag;
+    wmma::fill_fragment(acc_frag, 0.0f);
+
+    for (int k = 0; k < D; k += LOGITS_WMMA_K) {
+        wmma::load_matrix_sync(a_frag, hidden + static_cast<int64_t>(row0) * D + k, D);
+        wmma::load_matrix_sync(b_frag, weight + static_cast<int64_t>(col0) * D + k, D);
+        wmma::mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+    }
+
+    wmma::store_matrix_sync(logits + static_cast<int64_t>(row0) * logits_stride0 + col0,
+                            acc_frag, logits_stride0, wmma::mem_row_major);
+}
+
+__global__ void fused_linear_logp_grad_weight_tile_wmma_kernel(
+    const nv_bfloat16 *__restrict__ dlogits,
+    const nv_bfloat16 *__restrict__ hidden,
+    nv_bfloat16 *__restrict__ grad_weight,
+    int N,
+    int D,
+    int V,
+    int64_t dlogits_stride0,
+    int64_t hidden_stride0,
+    int64_t grad_weight_stride0) {
+    const int warp_in_block = threadIdx.x / 32;
+    const int lane = threadIdx.x % 32;
+    const int d_tiles = D / GRAD_W_WMMA_N;
+    const int total_tiles = (V / GRAD_W_WMMA_M) * d_tiles;
+    const int tile_idx = blockIdx.x * GRAD_W_WMMA_WARPS + warp_in_block;
+    if (tile_idx >= total_tiles)
+        return;
+
+    const int v_tile = tile_idx / d_tiles;
+    const int d_tile = tile_idx - v_tile * d_tiles;
+    const int v0 = v_tile * GRAD_W_WMMA_M;
+    const int d0 = d_tile * GRAD_W_WMMA_N;
+
+    wmma::fragment<wmma::matrix_a, GRAD_W_WMMA_M, GRAD_W_WMMA_N, GRAD_W_WMMA_K,
+                   nv_bfloat16, wmma::col_major>
+        a_frag;
+    wmma::fragment<wmma::matrix_b, GRAD_W_WMMA_M, GRAD_W_WMMA_N, GRAD_W_WMMA_K,
+                   nv_bfloat16, wmma::row_major>
+        b_frag;
+    wmma::fragment<wmma::accumulator, GRAD_W_WMMA_M, GRAD_W_WMMA_N, GRAD_W_WMMA_K,
+                   float>
+        acc_frag;
+    wmma::fill_fragment(acc_frag, 0.0f);
+
+    for (int n0 = 0; n0 < N; n0 += GRAD_W_WMMA_K) {
+        // A = dlogits.T tile [V, N]. dlogits is [N, V] row-major, so the
+        // transposed A tile is naturally column-major with lda=dlogits_stride0.
+        wmma::load_matrix_sync(
+            a_frag,
+            reinterpret_cast<const nv_bfloat16 *>(
+                dlogits + static_cast<int64_t>(n0) * dlogits_stride0 + v0),
+            dlogits_stride0);
+        // B = hidden tile [N, D], row-major.
+        wmma::load_matrix_sync(
+            b_frag,
+            reinterpret_cast<const nv_bfloat16 *>(
+                hidden + static_cast<int64_t>(n0) * hidden_stride0 + d0),
+            hidden_stride0);
+        wmma::mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+    }
+
+    extern __shared__ char grad_w_smem_raw[];
+    float *tile_out = reinterpret_cast<float *>(grad_w_smem_raw) +
+                      warp_in_block * GRAD_W_WMMA_M * GRAD_W_WMMA_N;
+    wmma::store_matrix_sync(tile_out, acc_frag, GRAD_W_WMMA_N, wmma::mem_row_major);
+    __syncwarp();
+
+    for (int idx = lane; idx < GRAD_W_WMMA_M * GRAD_W_WMMA_N; idx += 32) {
+        const int vr = idx / GRAD_W_WMMA_N;
+        const int dc = idx - vr * GRAD_W_WMMA_N;
+        grad_weight[static_cast<int64_t>(v0 + vr) * grad_weight_stride0 + d0 + dc] =
+            __float2bfloat16(tile_out[idx]);
+    }
+}
+
+__global__ void fused_linear_logp_grad_weight_from_logits_tile_wmma_kernel(
+    const float *__restrict__ logits_or_probs,
+    const nv_bfloat16 *__restrict__ hidden,
+    const int *__restrict__ target,
+    const float *__restrict__ grad_logp,
+    const float *__restrict__ lse,
+    nv_bfloat16 *__restrict__ grad_weight,
+    int N,
+    int D,
+    int V,
+    int64_t logits_stride0,
+    int64_t hidden_stride0,
+    int64_t grad_weight_stride0,
+    int vocab_start_index,
+    bool logits_are_probs) {
+    const int warp_in_block = threadIdx.x / 32;
+    const int lane = threadIdx.x % 32;
+    const int d_tiles = D / GRAD_W_WMMA_N;
+    const int d_groups = (d_tiles + GRAD_W_WMMA_WARPS - 1) / GRAD_W_WMMA_WARPS;
+    const int block_tile = blockIdx.x;
+    const int v_tile = block_tile / d_groups;
+    const int d_group = block_tile - v_tile * d_groups;
+    const int d_tile = d_group * GRAD_W_WMMA_WARPS + warp_in_block;
+    const int v0 = v_tile * GRAD_W_WMMA_M;
+    const int d0 = d_tile * GRAD_W_WMMA_N;
+    const bool valid_d_tile = d_tile < d_tiles;
+
+    extern __shared__ __align__(16) char smem_raw[];
+    nv_bfloat16 *dlogits_tile = reinterpret_cast<nv_bfloat16 *>(smem_raw);
+    float *tile_out = reinterpret_cast<float *>(dlogits_tile + GRAD_W_WMMA_M * GRAD_W_WMMA_K) +
+                      warp_in_block * GRAD_W_WMMA_M * GRAD_W_WMMA_N;
+
+    wmma::fragment<wmma::matrix_a, GRAD_W_WMMA_M, GRAD_W_WMMA_N, GRAD_W_WMMA_K,
+                   nv_bfloat16, wmma::col_major>
+        a_frag;
+    wmma::fragment<wmma::matrix_b, GRAD_W_WMMA_M, GRAD_W_WMMA_N, GRAD_W_WMMA_K,
+                   nv_bfloat16, wmma::row_major>
+        b_frag;
+    wmma::fragment<wmma::accumulator, GRAD_W_WMMA_M, GRAD_W_WMMA_N, GRAD_W_WMMA_K,
+                   float>
+        acc_frag;
+    wmma::fill_fragment(acc_frag, 0.0f);
+
+    for (int n0 = 0; n0 < N; n0 += GRAD_W_WMMA_K) {
+        if (threadIdx.x < GRAD_W_WMMA_M * GRAD_W_WMMA_K) {
+            const int vr = threadIdx.x % GRAD_W_WMMA_M;
+            const int nk = threadIdx.x / GRAD_W_WMMA_M;
+            const int n = n0 + nk;
+            const int v = v0 + vr;
+            const float src =
+                logits_or_probs[static_cast<int64_t>(n) * logits_stride0 + v];
+            float dz = logits_are_probs ? -src : -__expf(src - lse[n]);
+            if (target[n] == vocab_start_index + v)
+                dz += 1.0f;
+            dlogits_tile[vr + nk * GRAD_W_WMMA_M] = __float2bfloat16(dz * grad_logp[n]);
+        }
+        __syncthreads();
+
+        if (valid_d_tile) {
+            wmma::load_matrix_sync(a_frag, dlogits_tile, GRAD_W_WMMA_M);
+            wmma::load_matrix_sync(
+                b_frag,
+                reinterpret_cast<const nv_bfloat16 *>(
+                    hidden + static_cast<int64_t>(n0) * hidden_stride0 + d0),
+                hidden_stride0);
+            wmma::mma_sync(acc_frag, a_frag, b_frag, acc_frag);
+        }
+        __syncthreads();
+    }
+
+    if (!valid_d_tile)
+        return;
+
+    wmma::store_matrix_sync(tile_out, acc_frag, GRAD_W_WMMA_N, wmma::mem_row_major);
+    __syncwarp();
+
+    for (int idx = lane; idx < GRAD_W_WMMA_M * GRAD_W_WMMA_N; idx += 32) {
+        const int vr = idx / GRAD_W_WMMA_N;
+        const int dc = idx - vr * GRAD_W_WMMA_N;
+        grad_weight[static_cast<int64_t>(v0 + vr) * grad_weight_stride0 + d0 + dc] =
+            __float2bfloat16(tile_out[idx]);
+    }
+}
+
+bool fused_backward_use_input_precision_gemm(const torch::Tensor &hidden,
+                                             const torch::Tensor &weight) {
+    const char *precision_env = std::getenv("RL_KERNEL_LINEAR_LOGP_FUSED_BWD_PRECISION");
+    if (precision_env != nullptr) {
+        std::string precision(precision_env);
+        std::transform(precision.begin(), precision.end(), precision.begin(), ::tolower);
+        if (precision == "fp32")
+            return false;
+        if (precision == "input" || precision == "bf16" || precision == "auto")
+            return true;
+    }
+    return hidden.scalar_type() == weight.scalar_type() &&
+           (hidden.scalar_type() == at::kBFloat16 || hidden.scalar_type() == at::kHalf);
+}
+
+bool fused_backward_use_input_precision_logits() {
+    const char *precision_env = std::getenv("RL_KERNEL_LINEAR_LOGP_FUSED_BWD_PRECISION");
+    if (precision_env == nullptr)
+        return false;
+    std::string precision(precision_env);
+    std::transform(precision.begin(), precision.end(), precision.begin(), ::tolower);
+    return precision == "input_all" || precision == "bf16_all";
+}
+
+bool fused_backward_bf16_dlogits_enabled() {
+    const char *enabled_env = std::getenv("RL_KERNEL_LINEAR_LOGP_FUSED_BWD_BF16_DLOGITS");
+    if (enabled_env == nullptr)
+        return true;
+    std::string enabled(enabled_env);
+    std::transform(enabled.begin(), enabled.end(), enabled.begin(), ::tolower);
+    return enabled != "0" && enabled != "false" && enabled != "no" && enabled != "off";
+}
+
+bool fused_backward_rowwise_dlogits_enabled() {
+    const char *enabled_env = std::getenv("RL_KERNEL_LINEAR_LOGP_FUSED_BWD_ROWWISE_DLOGITS");
+    if (enabled_env == nullptr)
+        return true;
+    std::string enabled(enabled_env);
+    std::transform(enabled.begin(), enabled.end(), enabled.begin(), ::tolower);
+    return enabled != "0" && enabled != "false" && enabled != "no" && enabled != "off";
+}
+
+bool streaming_output_backward_enabled() {
+    const char *precision_env = std::getenv("RL_KERNEL_LINEAR_LOGP_FUSED_BWD_PRECISION");
+    if (precision_env != nullptr) {
+        std::string precision(precision_env);
+        std::transform(precision.begin(), precision.end(), precision.begin(), ::tolower);
+        if (precision == "fp32")
+            return false;
+    }
+    const char *enabled_env = std::getenv("RL_KERNEL_LINEAR_LOGP_STREAMING_BWD");
+    if (enabled_env == nullptr)
+        return false;
+    std::string enabled(enabled_env);
+    std::transform(enabled.begin(), enabled.end(), enabled.begin(), ::tolower);
+    return enabled != "0" && enabled != "false" && enabled != "no" && enabled != "off";
+}
+
+bool streaming_output_backward_scalar_mode() {
+    const char *mode_env = std::getenv("RL_KERNEL_LINEAR_LOGP_STREAMING_BWD_MODE");
+    if (mode_env == nullptr)
+        return false;
+    std::string mode(mode_env);
+    std::transform(mode.begin(), mode.end(), mode.begin(), ::tolower);
+    return mode == "scalar";
+}
+
+std::string streaming_output_backward_logits_mode() {
+    const char *mode_env = std::getenv("RL_KERNEL_LINEAR_LOGP_STREAMING_BWD_LOGITS");
+    if (mode_env == nullptr)
+        return "";
+    std::string mode(mode_env);
+    std::transform(mode.begin(), mode.end(), mode.begin(), ::tolower);
+    return mode;
+}
+
+bool streaming_output_backward_cuda_logits_enabled() {
+    const std::string mode = streaming_output_backward_logits_mode();
+    return mode == "cuda_tf32" || mode == "tf32" || mode == "wmma_tf32";
+}
+
+bool streaming_output_backward_bf16_mma_logits_enabled() {
+    const std::string mode = streaming_output_backward_logits_mode();
+    return mode == "cuda_bf16_mma" || mode == "bf16_mma" || mode == "sm90_mma";
+}
+
+bool streaming_output_backward_bf16_mma_dz_enabled() {
+    const std::string mode = streaming_output_backward_logits_mode();
+    return mode == "cuda_bf16_mma_dz" || mode == "bf16_mma_dz" ||
+           mode == "sm90_mma_dz";
+}
+
+std::string streaming_output_backward_grad_weight_mode() {
+    const char *mode_env = std::getenv("RL_KERNEL_LINEAR_LOGP_STREAMING_BWD_GW");
+    if (mode_env == nullptr)
+        return "";
+    std::string mode(mode_env);
+    std::transform(mode.begin(), mode.end(), mode.begin(), ::tolower);
+    return mode;
+}
+
+bool streaming_output_backward_grad_weight_wmma_enabled() {
+    const std::string mode = streaming_output_backward_grad_weight_mode();
+    return mode == "cuda_wmma" || mode == "wmma" || mode == "cuda_bf16_wmma";
+}
+
+bool fused_tile_backward_grad_weight_enabled() {
+    const char *enabled_env = std::getenv("RL_KERNEL_LINEAR_LOGP_FUSED_TILE_BWD");
+    if (enabled_env == nullptr)
+        enabled_env = std::getenv("RL_KERNEL_LINEAR_LOGP_FUSED_TILE_DW");
+    if (enabled_env != nullptr) {
+        std::string enabled(enabled_env);
+        std::transform(enabled.begin(), enabled.end(), enabled.begin(), ::tolower);
+        return enabled != "0" && enabled != "false" && enabled != "no" &&
+               enabled != "off";
+    }
+    const std::string mode = streaming_output_backward_grad_weight_mode();
+    return mode == "fused_tile" || mode == "tile_fused" || mode == "cuda_fused_tile";
+}
+
+std::string fused_tile_backward_full_grad_mode() {
+    const char *enabled_env = std::getenv("RL_KERNEL_LINEAR_LOGP_FUSED_TILE_BWD_FULL");
+    if (enabled_env == nullptr)
+        return "";
+    std::string enabled(enabled_env);
+    std::transform(enabled.begin(), enabled.end(), enabled.begin(), ::tolower);
+    if (enabled == "0" || enabled == "false" || enabled == "no" || enabled == "off")
+        return "";
+    if (enabled == "1" || enabled == "true" || enabled == "yes" || enabled == "on" ||
+        enabled == "auto")
+        return "tile_cublas";
+    return enabled;
+}
+
+bool save_probs_rowwise_dlogits_enabled() {
+    const char *enabled_env = std::getenv("RL_KERNEL_LINEAR_LOGP_SAVE_PROBS_ROWWISE_DLOGITS");
+    if (enabled_env == nullptr)
+        return true;
+    std::string enabled(enabled_env);
+    std::transform(enabled.begin(), enabled.end(), enabled.begin(), ::tolower);
+    return enabled != "0" && enabled != "false" && enabled != "no" && enabled != "off";
+}
+
+int streaming_output_backward_vocab_tile(int V) {
+    const char *tile_env = std::getenv("RL_KERNEL_LINEAR_LOGP_STREAMING_BWD_VOCAB_TILE");
+    int tile = 32768;
+    if (tile_env != nullptr) {
+        const int parsed = std::atoi(tile_env);
+        if (parsed > 0)
+            tile = parsed;
+    }
+    tile = std::max(1, tile);
+    if (V > 1)
+        tile = std::min(tile, V - 1);
+    else
+        tile = 1;
+    return tile;
+}
+
+bool can_use_logits_tile_tf32_wmma(int N, int D, int V) {
+    return N % LOGITS_WMMA_M == 0 && V % LOGITS_WMMA_N == 0 && D % LOGITS_WMMA_K == 0;
+}
+
+bool can_use_grad_weight_tile_wmma(int N, int D, int V) {
+    return N % GRAD_W_WMMA_K == 0 && D % GRAD_W_WMMA_N == 0 &&
+           V % GRAD_W_WMMA_M == 0;
+}
+
+void launch_logits_tile_tf32_wmma(torch::Tensor hidden,
+                                  torch::Tensor weight,
+                                  torch::Tensor logits) {
+    const int N = hidden.size(0);
+    const int D = hidden.size(1);
+    const int V = weight.size(0);
+    TORCH_CHECK(can_use_logits_tile_tf32_wmma(N, D, V),
+                "TF32 WMMA logits tile requires N % ", LOGITS_WMMA_M, " == 0, V % ",
+                LOGITS_WMMA_N, " == 0, and D % ", LOGITS_WMMA_K, " == 0");
+    const int tile_count = (N / LOGITS_WMMA_M) * (V / LOGITS_WMMA_N);
+    const int blocks = (tile_count + LOGITS_WMMA_WARPS - 1) / LOGITS_WMMA_WARPS;
+    fused_linear_logp_logits_tile_tf32_wmma_kernel<<<
+        blocks, LOGITS_WMMA_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+        hidden.data_ptr<float>(), weight.data_ptr<float>(), logits.data_ptr<float>(), N, D, V,
+        logits.stride(0));
+}
+
+void launch_logits_tile_bf16_mma(torch::Tensor hidden,
+                                 torch::Tensor weight,
+                                 torch::Tensor logits) {
+    TORCH_CHECK(hidden.scalar_type() == at::kBFloat16 && weight.scalar_type() == at::kBFloat16,
+                "bf16 MMA logits tile requires bf16 hidden and weight");
+    TORCH_CHECK(hidden.is_contiguous() && weight.is_contiguous(),
+                "bf16 MMA logits tile requires contiguous hidden and weight");
+    const int N = hidden.size(0);
+    const int D = hidden.size(1);
+    const int V = weight.size(0);
+    TORCH_CHECK(weight.size(1) == D, "hidden/weight hidden-dim mismatch");
+    TORCH_CHECK(D % BK == 0, "D must be a multiple of ", BK, " for bf16 MMA logits tile");
+
+    CUtensorMap h_tmap, w_tmap;
+    init_tensor_map_noswizzle(
+        &h_tmap, reinterpret_cast<const nv_bfloat16 *>(hidden.data_ptr<at::BFloat16>()), N, D, BM,
+        BK);
+    init_tensor_map_noswizzle(
+        &w_tmap, reinterpret_cast<const nv_bfloat16 *>(weight.data_ptr<at::BFloat16>()), V, D, BN,
+        BK);
+
+    const int smem = STAGES * (BM * BK + BN * BK) * sizeof(nv_bfloat16) +
+                     (BM * BN) * sizeof(float) + STAGES * 8;
+    if (smem > 48 * 1024) {
+        cudaFuncSetAttribute(fused_linear_logp_logits_tile_bf16_mma_kernel,
+                             cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+    }
+
+    const int row_blocks = (N + BM - 1) / BM;
+    const int total_vtiles = (V + BN - 1) / BN;
+    dim3 grid(row_blocks, total_vtiles);
+    fused_linear_logp_logits_tile_bf16_mma_kernel<<<
+        grid, WG_THREADS, smem, at::cuda::getCurrentCUDAStream()>>>(
+        h_tmap, w_tmap, logits.data_ptr<float>(), nullptr, nullptr, nullptr, nullptr, N, D, V,
+        logits.stride(0), 0, 0, false);
+}
+
+void launch_dlogits_tile_bf16_mma(torch::Tensor hidden,
+                                  torch::Tensor weight,
+                                  torch::Tensor dlogits,
+                                  torch::Tensor target,
+                                  torch::Tensor grad_logp,
+                                  torch::Tensor lse,
+                                  int vocab_start_index) {
+    TORCH_CHECK(hidden.scalar_type() == at::kBFloat16 && weight.scalar_type() == at::kBFloat16,
+                "bf16 MMA dlogits tile requires bf16 hidden and weight");
+    TORCH_CHECK(dlogits.scalar_type() == at::kBFloat16,
+                "bf16 MMA dlogits tile requires bf16 dlogits output");
+    TORCH_CHECK(hidden.is_contiguous() && weight.is_contiguous(),
+                "bf16 MMA dlogits tile requires contiguous hidden and weight");
+    TORCH_CHECK(target.is_contiguous() && grad_logp.is_contiguous() && lse.is_contiguous(),
+                "bf16 MMA dlogits tile requires contiguous target, grad_logp, and lse");
+    const int N = hidden.size(0);
+    const int D = hidden.size(1);
+    const int V = weight.size(0);
+    TORCH_CHECK(weight.size(1) == D, "hidden/weight hidden-dim mismatch");
+    TORCH_CHECK(dlogits.size(0) == N && dlogits.size(1) == V,
+                "dlogits tile shape must be [N, V]");
+    TORCH_CHECK(D % BK == 0, "D must be a multiple of ", BK, " for bf16 MMA dlogits tile");
+
+    CUtensorMap h_tmap, w_tmap;
+    init_tensor_map_noswizzle(
+        &h_tmap, reinterpret_cast<const nv_bfloat16 *>(hidden.data_ptr<at::BFloat16>()), N, D, BM,
+        BK);
+    init_tensor_map_noswizzle(
+        &w_tmap, reinterpret_cast<const nv_bfloat16 *>(weight.data_ptr<at::BFloat16>()), V, D, BN,
+        BK);
+
+    const int smem = STAGES * (BM * BK + BN * BK) * sizeof(nv_bfloat16) +
+                     (BM * BN) * sizeof(float) + STAGES * 8;
+    if (smem > 48 * 1024) {
+        cudaFuncSetAttribute(fused_linear_logp_logits_tile_bf16_mma_kernel,
+                             cudaFuncAttributeMaxDynamicSharedMemorySize, smem);
+    }
+
+    const int row_blocks = (N + BM - 1) / BM;
+    const int total_vtiles = (V + BN - 1) / BN;
+    dim3 grid(row_blocks, total_vtiles);
+    fused_linear_logp_logits_tile_bf16_mma_kernel<<<
+        grid, WG_THREADS, smem, at::cuda::getCurrentCUDAStream()>>>(
+        h_tmap, w_tmap, nullptr,
+        reinterpret_cast<nv_bfloat16 *>(dlogits.data_ptr<at::BFloat16>()),
+        target.data_ptr<int>(), grad_logp.data_ptr<float>(), lse.data_ptr<float>(), N, D, V, 0,
+        dlogits.stride(0), vocab_start_index, true);
+}
+
+void launch_grad_weight_tile_wmma(torch::Tensor dlogits,
+                                  torch::Tensor hidden,
+                                  torch::Tensor grad_weight) {
+    TORCH_CHECK(dlogits.scalar_type() == at::kBFloat16 &&
+                    hidden.scalar_type() == at::kBFloat16 &&
+                    grad_weight.scalar_type() == at::kBFloat16,
+                "WMMA grad_weight tile requires bf16 dlogits, hidden, and grad_weight");
+    TORCH_CHECK(hidden.is_contiguous(), "WMMA grad_weight tile requires contiguous hidden");
+    TORCH_CHECK(grad_weight.dim() == 2 && dlogits.dim() == 2 && hidden.dim() == 2,
+                "WMMA grad_weight tile expects 2-D tensors");
+    const int N = dlogits.size(0);
+    const int V = dlogits.size(1);
+    const int D = hidden.size(1);
+    TORCH_CHECK(hidden.size(0) == N, "dlogits/hidden token dimension mismatch");
+    TORCH_CHECK(grad_weight.size(0) == V && grad_weight.size(1) == D,
+                "grad_weight tile shape must be [V, D]");
+    TORCH_CHECK(can_use_grad_weight_tile_wmma(N, D, V),
+                "WMMA grad_weight tile requires N % ", GRAD_W_WMMA_K, " == 0, D % ",
+                GRAD_W_WMMA_N, " == 0, and V % ", GRAD_W_WMMA_M, " == 0");
+
+    const int d_tiles = D / GRAD_W_WMMA_N;
+    const int v_tiles = V / GRAD_W_WMMA_M;
+    const int tile_count = d_tiles * v_tiles;
+    const int blocks = (tile_count + GRAD_W_WMMA_WARPS - 1) / GRAD_W_WMMA_WARPS;
+    const int smem = GRAD_W_WMMA_WARPS * GRAD_W_WMMA_M * GRAD_W_WMMA_N * sizeof(float);
+    fused_linear_logp_grad_weight_tile_wmma_kernel<<<
+        blocks, GRAD_W_WMMA_THREADS, smem, at::cuda::getCurrentCUDAStream()>>>(
+        reinterpret_cast<const nv_bfloat16 *>(dlogits.data_ptr<at::BFloat16>()),
+        reinterpret_cast<const nv_bfloat16 *>(hidden.data_ptr<at::BFloat16>()),
+        reinterpret_cast<nv_bfloat16 *>(grad_weight.data_ptr<at::BFloat16>()), N, D, V,
+        dlogits.stride(0), hidden.stride(0), grad_weight.stride(0));
+}
+
+void launch_grad_weight_from_logits_tile_wmma(torch::Tensor logits_or_probs,
+                                              torch::Tensor hidden,
+                                              torch::Tensor target,
+                                              torch::Tensor grad_logp,
+                                              torch::Tensor lse,
+                                              torch::Tensor grad_weight,
+                                              int vocab_start_index,
+                                              bool logits_are_probs) {
+    TORCH_CHECK(logits_or_probs.scalar_type() == at::kFloat,
+                "fused tile grad_weight requires fp32 logits/probs");
+    TORCH_CHECK(hidden.scalar_type() == at::kBFloat16 &&
+                    grad_weight.scalar_type() == at::kBFloat16,
+                "fused tile grad_weight requires bf16 hidden and grad_weight");
+    TORCH_CHECK(hidden.is_contiguous(), "fused tile grad_weight requires contiguous hidden");
+    TORCH_CHECK(logits_or_probs.dim() == 2 && hidden.dim() == 2 && grad_weight.dim() == 2,
+                "fused tile grad_weight expects 2-D tensors");
+    TORCH_CHECK(logits_or_probs.stride(1) == 1 && hidden.stride(1) == 1 &&
+                    grad_weight.stride(1) == 1,
+                "fused tile grad_weight requires unit stride on the last dimension");
+    TORCH_CHECK(target.is_contiguous() && grad_logp.is_contiguous() && lse.is_contiguous(),
+                "fused tile grad_weight requires contiguous target, grad_logp, and lse");
+    TORCH_CHECK(target.scalar_type() == at::kInt,
+                "fused tile grad_weight requires int32 target");
+    TORCH_CHECK(grad_logp.scalar_type() == at::kFloat && lse.scalar_type() == at::kFloat,
+                "fused tile grad_weight requires fp32 grad_logp and lse");
+
+    const int N = logits_or_probs.size(0);
+    const int V = logits_or_probs.size(1);
+    const int D = hidden.size(1);
+    TORCH_CHECK(hidden.size(0) == N, "logits/hidden token dimension mismatch");
+    TORCH_CHECK(grad_weight.size(0) == V && grad_weight.size(1) == D,
+                "grad_weight tile shape must be [V, D]");
+    TORCH_CHECK(target.numel() == N && grad_logp.numel() == N && lse.numel() == N,
+                "target, grad_logp, and lse must have one value per token");
+    TORCH_CHECK(can_use_grad_weight_tile_wmma(N, D, V),
+                "fused tile grad_weight requires N % ", GRAD_W_WMMA_K, " == 0, D % ",
+                GRAD_W_WMMA_N, " == 0, and V % ", GRAD_W_WMMA_M, " == 0");
+
+    const int d_tiles = D / GRAD_W_WMMA_N;
+    const int d_groups = (d_tiles + GRAD_W_WMMA_WARPS - 1) / GRAD_W_WMMA_WARPS;
+    const int v_tiles = V / GRAD_W_WMMA_M;
+    const int blocks = v_tiles * d_groups;
+    const int smem = GRAD_W_WMMA_M * GRAD_W_WMMA_K * sizeof(nv_bfloat16) +
+                     GRAD_W_WMMA_WARPS * GRAD_W_WMMA_M * GRAD_W_WMMA_N * sizeof(float);
+    fused_linear_logp_grad_weight_from_logits_tile_wmma_kernel<<<
+        blocks, GRAD_W_WMMA_THREADS, smem, at::cuda::getCurrentCUDAStream()>>>(
+        logits_or_probs.data_ptr<float>(),
+        reinterpret_cast<const nv_bfloat16 *>(hidden.data_ptr<at::BFloat16>()),
+        target.data_ptr<int>(), grad_logp.data_ptr<float>(), lse.data_ptr<float>(),
+        reinterpret_cast<nv_bfloat16 *>(grad_weight.data_ptr<at::BFloat16>()), N, D, V,
+        logits_or_probs.stride(0), hidden.stride(0), grad_weight.stride(0),
+        vocab_start_index, logits_are_probs);
+}
+
+std::vector<torch::Tensor> linear_logp_probs_bf16_forward_impl(torch::Tensor logits,
+                                                               torch::Tensor target,
+                                                               int64_t vocab_start_index) {
+    TORCH_CHECK(logits.is_cuda() && target.is_cuda(), "logits and target must be CUDA tensors");
+    TORCH_CHECK(logits.scalar_type() == at::kBFloat16,
+                "linear_logp_probs_bf16_forward requires bf16 logits");
+    TORCH_CHECK(logits.dim() == 2, "logits must be 2-D [N, V]");
+    TORCH_CHECK(logits.is_contiguous(), "logits must be contiguous");
+    const int N = logits.size(0);
+    const int V = logits.size(1);
+    TORCH_CHECK(target.numel() == N, "target must have one id per row");
+
+    c10::cuda::CUDAGuard device_guard(logits.device());
+    auto target_i = target.reshape({N}).to(torch::kInt32).contiguous();
+    auto out = torch::empty({N}, logits.options().dtype(torch::kFloat));
+    auto probs = torch::empty_like(logits);
+    linear_logp_probs_bf16_forward_kernel<<<
+        N, 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+        reinterpret_cast<const nv_bfloat16 *>(logits.data_ptr<at::BFloat16>()),
+        target_i.data_ptr<int>(), out.data_ptr<float>(), nullptr, nullptr,
+        reinterpret_cast<nv_bfloat16 *>(probs.data_ptr<at::BFloat16>()), N, V,
+        logits.stride(0), probs.stride(0), static_cast<int>(vocab_start_index));
+    return {out, probs};
+}
+
+std::vector<torch::Tensor> linear_logp_bf16_forward_impl(torch::Tensor logits,
+                                                         torch::Tensor target,
+                                                         int64_t vocab_start_index) {
+    TORCH_CHECK(logits.is_cuda() && target.is_cuda(), "logits and target must be CUDA tensors");
+    TORCH_CHECK(logits.scalar_type() == at::kBFloat16,
+                "linear_logp_bf16_forward requires bf16 logits");
+    TORCH_CHECK(logits.dim() == 2, "logits must be 2-D [N, V]");
+    TORCH_CHECK(logits.is_contiguous(), "logits must be contiguous");
+    const int N = logits.size(0);
+    const int V = logits.size(1);
+    TORCH_CHECK(target.numel() == N, "target must have one id per row");
+
+    c10::cuda::CUDAGuard device_guard(logits.device());
+    auto target_i = target.reshape({N}).to(torch::kInt32).contiguous();
+    auto opts_f = logits.options().dtype(torch::kFloat);
+    auto out = torch::empty({N}, opts_f);
+    auto lse = torch::empty({N}, opts_f);
+    linear_logp_probs_bf16_forward_kernel<<<
+        N, 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+        reinterpret_cast<const nv_bfloat16 *>(logits.data_ptr<at::BFloat16>()),
+        target_i.data_ptr<int>(), out.data_ptr<float>(), nullptr, lse.data_ptr<float>(),
+        nullptr, N, V, logits.stride(0), 0, static_cast<int>(vocab_start_index));
+    return {out, lse};
+}
+
+std::vector<torch::Tensor> linear_logp_local_probs_bf16_forward_impl(
+    torch::Tensor logits, torch::Tensor target, int64_t vocab_start_index) {
+    TORCH_CHECK(logits.is_cuda() && target.is_cuda(), "logits and target must be CUDA tensors");
+    TORCH_CHECK(logits.scalar_type() == at::kBFloat16,
+                "linear_logp_local_probs_bf16_forward requires bf16 logits");
+    TORCH_CHECK(logits.dim() == 2, "logits must be 2-D [N, V]");
+    TORCH_CHECK(logits.is_contiguous(), "logits must be contiguous");
+    const int N = logits.size(0);
+    const int V = logits.size(1);
+    TORCH_CHECK(target.numel() == N, "target must have one id per row");
+
+    c10::cuda::CUDAGuard device_guard(logits.device());
+    auto target_i = target.reshape({N}).to(torch::kInt32).contiguous();
+    auto opts_f = logits.options().dtype(torch::kFloat);
+    auto local_target_logit = torch::empty({N}, opts_f);
+    auto local_lse = torch::empty({N}, opts_f);
+    auto probs = torch::empty_like(logits);
+    linear_logp_probs_bf16_forward_kernel<<<
+        N, 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+        reinterpret_cast<const nv_bfloat16 *>(logits.data_ptr<at::BFloat16>()),
+        target_i.data_ptr<int>(), nullptr, local_target_logit.data_ptr<float>(),
+        local_lse.data_ptr<float>(),
+        reinterpret_cast<nv_bfloat16 *>(probs.data_ptr<at::BFloat16>()), N, V,
+        logits.stride(0), probs.stride(0), static_cast<int>(vocab_start_index));
+    return {local_target_logit, local_lse, probs};
+}
+
+std::vector<torch::Tensor> linear_logp_local_bf16_forward_impl(
+    torch::Tensor logits, torch::Tensor target, int64_t vocab_start_index) {
+    TORCH_CHECK(logits.is_cuda() && target.is_cuda(), "logits and target must be CUDA tensors");
+    TORCH_CHECK(logits.scalar_type() == at::kBFloat16,
+                "linear_logp_local_bf16_forward requires bf16 logits");
+    TORCH_CHECK(logits.dim() == 2, "logits must be 2-D [N, V]");
+    TORCH_CHECK(logits.is_contiguous(), "logits must be contiguous");
+    const int N = logits.size(0);
+    const int V = logits.size(1);
+    TORCH_CHECK(target.numel() == N, "target must have one id per row");
+
+    c10::cuda::CUDAGuard device_guard(logits.device());
+    auto target_i = target.reshape({N}).to(torch::kInt32).contiguous();
+    auto opts_f = logits.options().dtype(torch::kFloat);
+    auto local_target_logit = torch::empty({N}, opts_f);
+    auto local_lse = torch::empty({N}, opts_f);
+    linear_logp_probs_bf16_forward_kernel<<<
+        N, 256, 0, at::cuda::getCurrentCUDAStream()>>>(
+        reinterpret_cast<const nv_bfloat16 *>(logits.data_ptr<at::BFloat16>()),
+        target_i.data_ptr<int>(), nullptr, local_target_logit.data_ptr<float>(),
+        local_lse.data_ptr<float>(), nullptr, N, V, logits.stride(0), 0,
+        static_cast<int>(vocab_start_index));
+    return {local_target_logit, local_lse};
+}
+
+torch::Tensor linear_logp_probs_bf16_to_dlogits_impl(torch::Tensor probs,
+                                                     torch::Tensor target,
+                                                     torch::Tensor grad_logp,
+                                                     int64_t vocab_start_index) {
+    TORCH_CHECK(probs.is_cuda() && target.is_cuda() && grad_logp.is_cuda(),
+                "probs, target, and grad_logp must be CUDA tensors");
+    TORCH_CHECK(probs.scalar_type() == at::kBFloat16,
+                "linear_logp_probs_bf16_to_dlogits_ requires bf16 probs");
+    TORCH_CHECK(probs.dim() == 2, "probs must be 2-D [N, V]");
+    const int N = probs.size(0);
+    const int V = probs.size(1);
+    TORCH_CHECK(target.numel() == N, "target must have one id per row");
+    TORCH_CHECK(grad_logp.numel() == N, "grad_logp must have one value per row");
+
+    c10::cuda::CUDAGuard device_guard(probs.device());
+    auto target_i = target.reshape({N}).to(torch::kInt32).contiguous();
+    auto grad_f = grad_logp.reshape({N}).to(torch::kFloat).contiguous();
+    const int threads = 256;
+    const int64_t total = static_cast<int64_t>(N) * V;
+    const int blocks = static_cast<int>((total + threads - 1) / threads);
+    linear_logp_probs_bf16_to_dlogits_kernel<<<
+        blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+        reinterpret_cast<nv_bfloat16 *>(probs.data_ptr<at::BFloat16>()), target_i.data_ptr<int>(),
+        grad_f.data_ptr<float>(), N, V, probs.stride(0), static_cast<int>(vocab_start_index));
+    return probs;
+}
+
+torch::Tensor linear_logp_local_probs_bf16_to_dlogits_impl(torch::Tensor probs,
+                                                           torch::Tensor target,
+                                                           torch::Tensor grad_logp,
+                                                           torch::Tensor local_lse,
+                                                           torch::Tensor global_lse,
+                                                           int64_t vocab_start_index) {
+    TORCH_CHECK(probs.is_cuda() && target.is_cuda() && grad_logp.is_cuda() &&
+                    local_lse.is_cuda() && global_lse.is_cuda(),
+                "probs, target, grad_logp, local_lse, and global_lse must be CUDA tensors");
+    TORCH_CHECK(probs.scalar_type() == at::kBFloat16,
+                "linear_logp_local_probs_bf16_to_dlogits_ requires bf16 probs");
+    TORCH_CHECK(local_lse.scalar_type() == at::kFloat && global_lse.scalar_type() == at::kFloat,
+                "local_lse and global_lse must be fp32");
+    TORCH_CHECK(probs.dim() == 2, "probs must be 2-D [N, V]");
+    const int N = probs.size(0);
+    const int V = probs.size(1);
+    TORCH_CHECK(target.numel() == N, "target must have one id per row");
+    TORCH_CHECK(grad_logp.numel() == N, "grad_logp must have one value per row");
+    TORCH_CHECK(local_lse.numel() == N && global_lse.numel() == N,
+                "local_lse/global_lse must have one value per row");
+
+    c10::cuda::CUDAGuard device_guard(probs.device());
+    auto target_i = target.reshape({N}).to(torch::kInt32).contiguous();
+    auto grad_f = grad_logp.reshape({N}).to(torch::kFloat).contiguous();
+    auto local_lse_f = local_lse.reshape({N}).to(torch::kFloat).contiguous();
+    auto global_lse_f = global_lse.reshape({N}).to(torch::kFloat).contiguous();
+    const int threads = 256;
+    if (save_probs_rowwise_dlogits_enabled() && V >= threads) {
+        linear_logp_local_probs_bf16_to_dlogits_row_kernel<<<
+            N, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+            reinterpret_cast<nv_bfloat16 *>(probs.data_ptr<at::BFloat16>()),
+            target_i.data_ptr<int>(), grad_f.data_ptr<float>(), local_lse_f.data_ptr<float>(),
+            global_lse_f.data_ptr<float>(), N, V, probs.stride(0),
+            static_cast<int>(vocab_start_index));
+    } else {
+        const int64_t total = static_cast<int64_t>(N) * V;
+        const int blocks = static_cast<int>((total + threads - 1) / threads);
+        linear_logp_local_probs_bf16_to_dlogits_kernel<<<
+            blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+            reinterpret_cast<nv_bfloat16 *>(probs.data_ptr<at::BFloat16>()),
+            target_i.data_ptr<int>(), grad_f.data_ptr<float>(), local_lse_f.data_ptr<float>(),
+            global_lse_f.data_ptr<float>(), N, V, probs.stride(0),
+            static_cast<int>(vocab_start_index));
+    }
+    return probs;
+}
+
+torch::Tensor linear_logp_logits_bf16_to_dlogits_impl(torch::Tensor logits,
+                                                      torch::Tensor dlogits,
+                                                      torch::Tensor target,
+                                                      torch::Tensor grad_logp,
+                                                      torch::Tensor lse,
+                                                      int64_t vocab_start_index) {
+    TORCH_CHECK(logits.is_cuda() && dlogits.is_cuda() && target.is_cuda() &&
+                    grad_logp.is_cuda() && lse.is_cuda(),
+                "logits, dlogits, target, grad_logp, and lse must be CUDA tensors");
+    TORCH_CHECK(logits.scalar_type() == at::kBFloat16 &&
+                    dlogits.scalar_type() == at::kBFloat16,
+                "linear_logp_logits_bf16_to_dlogits requires bf16 logits/dlogits");
+    TORCH_CHECK(lse.scalar_type() == at::kFloat,
+                "linear_logp_logits_bf16_to_dlogits requires fp32 lse");
+    TORCH_CHECK(logits.dim() == 2 && dlogits.dim() == 2,
+                "logits and dlogits must be 2-D [N, V]");
+    const int N = logits.size(0);
+    const int V = logits.size(1);
+    TORCH_CHECK(dlogits.size(0) == N && dlogits.size(1) == V,
+                "dlogits shape must match logits");
+    TORCH_CHECK(logits.stride(1) == 1 && dlogits.stride(1) == 1,
+                "linear_logp_logits_bf16_to_dlogits requires unit last-dim stride");
+    TORCH_CHECK(target.numel() == N && grad_logp.numel() == N && lse.numel() == N,
+                "target, grad_logp, and lse must have one value per row");
+
+    c10::cuda::CUDAGuard device_guard(logits.device());
+    auto target_i = target.reshape({N}).to(torch::kInt32).contiguous();
+    auto grad_f = grad_logp.reshape({N}).to(torch::kFloat).contiguous();
+    auto lse_f = lse.reshape({N}).to(torch::kFloat).contiguous();
+    const int threads = 256;
+    if (V >= threads) {
+        linear_logp_logits_bf16_to_dlogits_row_kernel<<<
+            N, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+            reinterpret_cast<const nv_bfloat16 *>(logits.data_ptr<at::BFloat16>()),
+            reinterpret_cast<nv_bfloat16 *>(dlogits.data_ptr<at::BFloat16>()),
+            target_i.data_ptr<int>(), grad_f.data_ptr<float>(), lse_f.data_ptr<float>(), N, V,
+            logits.stride(0), dlogits.stride(0), static_cast<int>(vocab_start_index));
+    } else {
+        const int64_t total = static_cast<int64_t>(N) * V;
+        const int blocks = static_cast<int>((total + threads - 1) / threads);
+        linear_logp_logits_bf16_to_dlogits_kernel<<<
+            blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+            reinterpret_cast<const nv_bfloat16 *>(logits.data_ptr<at::BFloat16>()),
+            reinterpret_cast<nv_bfloat16 *>(dlogits.data_ptr<at::BFloat16>()),
+            target_i.data_ptr<int>(), grad_f.data_ptr<float>(), lse_f.data_ptr<float>(), N, V,
+            logits.stride(0), dlogits.stride(0), static_cast<int>(vocab_start_index));
+    }
+    return dlogits;
+}
+
+__global__ void fused_linear_logp_output_only_bwd_stream_kernel(
+    const nv_bfloat16 *__restrict__ hidden,
+    const nv_bfloat16 *__restrict__ weight,
+    const int *__restrict__ target,
+    const float *__restrict__ grad_logp,
+    const float *__restrict__ lse,
+    const float *__restrict__ bias,
+    nv_bfloat16 *__restrict__ grad_weight,
+    float *__restrict__ grad_bias,
+    int N,
+    int D,
+    int V,
+    int vocab_start_index,
+    bool has_bias,
+    bool compute_grad_bias) {
+    __shared__ float reduce_buf[STREAM_BWD_VECS][STREAM_BWD_THREADS];
+
+    const int tid = threadIdx.x;
+    const int v_base = blockIdx.x * STREAM_BWD_VECS;
+    const int slot_count = (D + STREAM_BWD_THREADS - 1 - tid) / STREAM_BWD_THREADS;
+
+    float acc[STREAM_BWD_VECS][STREAM_BWD_MAX_SLOTS];
+#pragma unroll
+    for (int j = 0; j < STREAM_BWD_VECS; ++j) {
+#pragma unroll
+        for (int s = 0; s < STREAM_BWD_MAX_SLOTS; ++s)
+            acc[j][s] = 0.0f;
+    }
+    float bias_acc[STREAM_BWD_VECS] = {0.0f, 0.0f, 0.0f, 0.0f};
+
+    for (int n = 0; n < N; ++n) {
+        float hvals[STREAM_BWD_MAX_SLOTS];
+#pragma unroll
+        for (int s = 0; s < STREAM_BWD_MAX_SLOTS; ++s) {
+            const int d = tid + s * STREAM_BWD_THREADS;
+            hvals[s] = (s < slot_count && d < D)
+                           ? __bfloat162float(hidden[static_cast<int64_t>(n) * D + d])
+                           : 0.0f;
+        }
+
+#pragma unroll
+        for (int j = 0; j < STREAM_BWD_VECS; ++j) {
+            const int v = v_base + j;
+            float partial = 0.0f;
+            if (v < V) {
+#pragma unroll
+                for (int s = 0; s < STREAM_BWD_MAX_SLOTS; ++s) {
+                    const int d = tid + s * STREAM_BWD_THREADS;
+                    if (s < slot_count && d < D) {
+                        partial +=
+                            hvals[s] *
+                            __bfloat162float(weight[static_cast<int64_t>(v) * D + d]);
+                    }
+                }
+            }
+            reduce_buf[j][tid] = partial;
+        }
+        __syncthreads();
+
+        for (int offset = STREAM_BWD_THREADS / 2; offset > 0; offset >>= 1) {
+            if (tid < offset) {
+#pragma unroll
+                for (int j = 0; j < STREAM_BWD_VECS; ++j)
+                    reduce_buf[j][tid] += reduce_buf[j][tid + offset];
+            }
+            __syncthreads();
+        }
+
+#pragma unroll
+        for (int j = 0; j < STREAM_BWD_VECS; ++j) {
+            const int v = v_base + j;
+            if (v >= V)
+                continue;
+            float logit = reduce_buf[j][0];
+            if (has_bias)
+                logit += bias[v];
+            float dz = -__expf(logit - lse[n]);
+            if (target[n] == vocab_start_index + v)
+                dz += 1.0f;
+            dz *= grad_logp[n];
+            if (tid == 0 && compute_grad_bias)
+                bias_acc[j] += dz;
+#pragma unroll
+            for (int s = 0; s < STREAM_BWD_MAX_SLOTS; ++s) {
+                const int d = tid + s * STREAM_BWD_THREADS;
+                if (s < slot_count && d < D)
+                    acc[j][s] += dz * hvals[s];
+            }
+        }
+        __syncthreads();
+    }
+
+#pragma unroll
+    for (int j = 0; j < STREAM_BWD_VECS; ++j) {
+        const int v = v_base + j;
+        if (v >= V)
+            continue;
+#pragma unroll
+        for (int s = 0; s < STREAM_BWD_MAX_SLOTS; ++s) {
+            const int d = tid + s * STREAM_BWD_THREADS;
+            if (s < slot_count && d < D) {
+                grad_weight[static_cast<int64_t>(v) * D + d] = __float2bfloat16(acc[j][s]);
+            }
+        }
+        if (tid == 0 && compute_grad_bias)
+            grad_bias[v] = bias_acc[j];
+    }
 }
 
 // 2D bf16 tensor map with swizzle pinned to NONE. This kernel reads its tiles
@@ -299,13 +1719,60 @@ inline void init_tensor_map_noswizzle(CUtensorMap *tmap, const nv_bfloat16 *gmem
 
 } // namespace
 
-// Forward: hidden [N, D] bf16, weight [V, D] bf16, target [N] int32, optional
-// bias [V] f32. Returns (logp [N] f32, lse [N] f32). Logits are never
-// materialized; peak extra memory is the per-CTA shared-memory tiles.
-std::vector<torch::Tensor> fused_linear_logp_sm90_forward(torch::Tensor hidden,
-                                                          torch::Tensor weight,
+std::vector<torch::Tensor> linear_logp_probs_bf16_forward(torch::Tensor logits,
                                                           torch::Tensor target,
-                                                          torch::optional<torch::Tensor> bias) {
+                                                          int64_t vocab_start_index) {
+    return linear_logp_probs_bf16_forward_impl(logits, target, vocab_start_index);
+}
+
+std::vector<torch::Tensor> linear_logp_bf16_forward(torch::Tensor logits,
+                                                    torch::Tensor target,
+                                                    int64_t vocab_start_index) {
+    return linear_logp_bf16_forward_impl(logits, target, vocab_start_index);
+}
+
+std::vector<torch::Tensor> linear_logp_local_probs_bf16_forward(torch::Tensor logits,
+                                                                torch::Tensor target,
+                                                                int64_t vocab_start_index) {
+    return linear_logp_local_probs_bf16_forward_impl(logits, target, vocab_start_index);
+}
+
+std::vector<torch::Tensor> linear_logp_local_bf16_forward(torch::Tensor logits,
+                                                          torch::Tensor target,
+                                                          int64_t vocab_start_index) {
+    return linear_logp_local_bf16_forward_impl(logits, target, vocab_start_index);
+}
+
+torch::Tensor linear_logp_probs_bf16_to_dlogits_(torch::Tensor probs,
+                                                 torch::Tensor target,
+                                                 torch::Tensor grad_logp,
+                                                 int64_t vocab_start_index) {
+    return linear_logp_probs_bf16_to_dlogits_impl(probs, target, grad_logp, vocab_start_index);
+}
+
+torch::Tensor linear_logp_local_probs_bf16_to_dlogits_(torch::Tensor probs,
+                                                       torch::Tensor target,
+                                                       torch::Tensor grad_logp,
+                                                       torch::Tensor local_lse,
+                                                       torch::Tensor global_lse,
+                                                       int64_t vocab_start_index) {
+    return linear_logp_local_probs_bf16_to_dlogits_impl(probs, target, grad_logp, local_lse,
+                                                       global_lse, vocab_start_index);
+}
+
+torch::Tensor linear_logp_logits_bf16_to_dlogits(torch::Tensor logits,
+                                                 torch::Tensor dlogits,
+                                                 torch::Tensor target,
+                                                 torch::Tensor grad_logp,
+                                                 torch::Tensor lse,
+                                                 int64_t vocab_start_index) {
+    return linear_logp_logits_bf16_to_dlogits_impl(logits, dlogits, target, grad_logp, lse,
+                                                  vocab_start_index);
+}
+
+std::vector<torch::Tensor> fused_linear_logp_sm90_forward_impl(
+    torch::Tensor hidden, torch::Tensor weight, torch::Tensor target,
+    torch::optional<torch::Tensor> bias, int64_t vocab_start_index, bool return_target_logit) {
     TORCH_CHECK(hidden.is_cuda() && weight.is_cuda(), "hidden and weight must be CUDA tensors");
     TORCH_CHECK(weight.device() == hidden.device(),
                 "lm_head_weight must be on the same device as hidden");
@@ -326,7 +1793,7 @@ std::vector<torch::Tensor> fused_linear_logp_sm90_forward(torch::Tensor hidden,
     }
 
     auto opts_f = hidden.options().dtype(torch::kFloat);
-    auto logp = torch::empty({N}, opts_f);
+    auto out_value = torch::empty({N}, opts_f);
     auto lse = torch::empty({N}, opts_f);
 
     // TMA descriptors: box [rows=BM/BN, cols=BK], unswizzled (see helper above).
@@ -369,13 +1836,384 @@ std::vector<torch::Tensor> fused_linear_logp_sm90_forward(torch::Tensor hidden,
     dim3 grid(row_blocks, n_split);
     fused_linear_logp_sm90_kernel<<<grid, WG_THREADS, smem>>>(
         h_tmap, w_tmap, target_i.data_ptr<int>(), bias_ptr, part_max.data_ptr<float>(),
-        part_sum.data_ptr<float>(), part_zt.data_ptr<float>(), N, D, V, n_split);
+        part_sum.data_ptr<float>(), part_zt.data_ptr<float>(), N, D, V, n_split,
+        static_cast<int>(vocab_start_index));
 
     const int combine_threads = 256;
     const int combine_blocks = (N + combine_threads - 1) / combine_threads;
     fused_linear_logp_sm90_combine_kernel<<<combine_blocks, combine_threads>>>(
         part_max.data_ptr<float>(), part_sum.data_ptr<float>(), part_zt.data_ptr<float>(),
-        logp.data_ptr<float>(), lse.data_ptr<float>(), N, n_split);
+        out_value.data_ptr<float>(), lse.data_ptr<float>(), N, n_split, return_target_logit);
 
-    return {logp, lse};
+    return {out_value, lse};
+}
+
+// Forward: hidden [N, D] bf16, weight [V, D] bf16, target [N] int32, optional
+// bias [V] f32. Returns (logp [N] f32, lse [N] f32). Logits are never
+// materialized; peak extra memory is the per-CTA shared-memory tiles.
+std::vector<torch::Tensor> fused_linear_logp_sm90_forward(torch::Tensor hidden,
+                                                          torch::Tensor weight,
+                                                          torch::Tensor target,
+                                                          torch::optional<torch::Tensor> bias) {
+    return fused_linear_logp_sm90_forward_impl(hidden, weight, target, bias, 0, false);
+}
+
+// Vocab-parallel local-shard forward. Target ids stay in global-vocab
+// coordinates and the kernel captures only the target logit owned by this shard.
+// Returns (local_target_logit [N] f32, local_lse [N] f32).
+std::vector<torch::Tensor> fused_linear_logp_sm90_global_target_forward(
+    torch::Tensor hidden, torch::Tensor weight, torch::Tensor target,
+    torch::optional<torch::Tensor> bias, int64_t vocab_start_index) {
+    return fused_linear_logp_sm90_forward_impl(
+        hidden, weight, target, bias, vocab_start_index, true);
+}
+
+// Backward fast path: compute local dlogits in one CUDA kernel, then use GEMMs
+// for the linear gradients. It intentionally materializes local logits/dlogits
+// to remove Python chunk loops and many small matmul dispatches from the hot
+// path. Non-TP recomputes lse from the backward logits so its gradients match
+// the shared chunked backward numerics. For vocab-parallel TP, lse must already
+// be the global lse and target is still in global-vocab coordinates.
+std::vector<torch::Tensor> fused_linear_logp_sm90_backward(torch::Tensor grad_logp,
+                                                           torch::Tensor hidden,
+                                                           torch::Tensor weight,
+                                                           torch::Tensor target,
+                                                           torch::Tensor lse,
+                                                           torch::optional<torch::Tensor> bias,
+                                                           int64_t vocab_start_index,
+                                                           bool compute_grad_hidden,
+                                                           bool compute_grad_weight,
+                                                           bool compute_grad_bias,
+                                                           bool use_global_lse) {
+    TORCH_CHECK(hidden.is_cuda() && weight.is_cuda(), "hidden and weight must be CUDA tensors");
+    TORCH_CHECK(weight.device() == hidden.device(),
+                "lm_head_weight must be on the same device as hidden");
+    TORCH_CHECK(hidden.is_contiguous() && weight.is_contiguous(), "inputs must be contiguous");
+    TORCH_CHECK(hidden.dim() == 2 && weight.dim() == 2, "hidden/weight must be 2-D tensors");
+    const int N = hidden.size(0);
+    const int D = hidden.size(1);
+    const int V = weight.size(0);
+    TORCH_CHECK(weight.size(1) == D, "hidden/weight hidden-dim mismatch");
+    TORCH_CHECK(target.numel() == N, "target must have one id per token");
+    TORCH_CHECK(lse.numel() == N, "lse must have one value per token");
+    TORCH_CHECK(grad_logp.numel() == N, "grad_logp must have one value per token");
+    if (bias.has_value()) {
+        TORCH_CHECK(bias->device() == hidden.device(),
+                    "bias must be on the same device as hidden");
+        TORCH_CHECK(bias->numel() == V, "bias must have V=", V, " elements, got ",
+                    bias->numel());
+    }
+
+    c10::cuda::CUDAGuard device_guard(hidden.device());
+    auto opts_f = hidden.options().dtype(torch::kFloat);
+    auto empty = torch::empty({0}, opts_f);
+
+    if (streaming_output_backward_enabled() && !compute_grad_hidden && compute_grad_weight &&
+        hidden.scalar_type() == at::kBFloat16 && weight.scalar_type() == at::kBFloat16 &&
+        D <= STREAM_BWD_MAX_D) {
+        if (!streaming_output_backward_scalar_mode() && !compute_grad_bias) {
+            auto grad_weight = torch::empty_like(weight);
+            auto grad_f = grad_logp.reshape({N}).to(torch::kFloat).contiguous();
+            auto lse_f = lse.reshape({N}).to(torch::kFloat).contiguous();
+            auto target_i = target.reshape({N}).to(torch::kInt32).contiguous();
+            auto hidden_gemm = hidden.contiguous();
+            const int tile_v = streaming_output_backward_vocab_tile(V);
+            const int threads = 256;
+            const bool use_cuda_tf32_logits = streaming_output_backward_cuda_logits_enabled();
+            const bool use_fused_tile_dw =
+                fused_tile_backward_grad_weight_enabled() &&
+                can_use_grad_weight_tile_wmma(N, D, V) &&
+                (tile_v % GRAD_W_WMMA_M == 0);
+            const bool requested_bf16_mma_dz =
+                streaming_output_backward_bf16_mma_dz_enabled() && D % BK == 0 &&
+                !bias.has_value();
+            const bool use_bf16_mma_logits =
+                (streaming_output_backward_bf16_mma_logits_enabled() ||
+                 (use_fused_tile_dw && requested_bf16_mma_dz)) &&
+                D % BK == 0;
+            const bool use_bf16_mma_dz =
+                requested_bf16_mma_dz && !use_fused_tile_dw;
+            const bool use_bf16_mma_tile = use_bf16_mma_logits || use_bf16_mma_dz;
+            const bool use_grad_weight_wmma =
+                !use_fused_tile_dw && streaming_output_backward_grad_weight_wmma_enabled();
+            torch::Tensor hidden_logits;
+            if (!use_bf16_mma_tile)
+                hidden_logits = hidden.to(torch::kFloat).contiguous();
+            torch::Tensor weight_logits_workspace;
+            if (!use_bf16_mma_tile)
+                weight_logits_workspace = torch::empty({tile_v, D}, opts_f);
+            torch::Tensor logits_workspace;
+            if (!use_bf16_mma_dz)
+                logits_workspace = torch::empty({N, tile_v}, opts_f);
+            torch::Tensor dlogits_workspace;
+            if (!use_fused_tile_dw)
+                dlogits_workspace = torch::empty({N, tile_v}, hidden.options());
+
+            for (int v0 = 0; v0 < V; v0 += tile_v) {
+                const int vc = std::min(tile_v, V - v0);
+                auto weight_tile = weight.narrow(0, v0, vc);
+                torch::Tensor dlogits_gemm;
+                if (!use_fused_tile_dw)
+                    dlogits_gemm = dlogits_workspace.narrow(1, 0, vc);
+                if (use_bf16_mma_dz) {
+                    launch_dlogits_tile_bf16_mma(
+                        hidden, weight_tile, dlogits_gemm, target_i, grad_f, lse_f,
+                        static_cast<int>(vocab_start_index + v0));
+                } else {
+                    auto logits = logits_workspace.narrow(1, 0, vc);
+                    if (use_bf16_mma_logits) {
+                        launch_logits_tile_bf16_mma(hidden, weight_tile, logits);
+                    } else {
+                        auto weight_logits = weight_logits_workspace.narrow(0, 0, vc);
+                        weight_logits.copy_(weight_tile);
+                        if (use_cuda_tf32_logits && can_use_logits_tile_tf32_wmma(N, D, vc))
+                            launch_logits_tile_tf32_wmma(hidden_logits, weight_logits, logits);
+                        else
+                            at::mm_out(logits, hidden_logits, weight_logits.transpose(0, 1));
+                    }
+                    if (bias.has_value()) {
+                        auto bias_tile = bias->narrow(0, v0, vc).to(torch::kFloat).contiguous();
+                        logits.add_(bias_tile);
+                    }
+
+                    auto grad_weight_view = grad_weight.narrow(0, v0, vc);
+                    if (use_fused_tile_dw) {
+                        launch_grad_weight_from_logits_tile_wmma(
+                            logits, hidden_gemm, target_i, grad_f, lse_f, grad_weight_view,
+                            static_cast<int>(vocab_start_index + v0), false);
+                        continue;
+                    }
+
+                    const int64_t total = static_cast<int64_t>(N) * vc;
+                    const int blocks = static_cast<int>((total + threads - 1) / threads);
+                    fused_linear_logp_backward_dlogits_bf16_kernel<<<
+                        blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+                        logits.data_ptr<float>(),
+                        reinterpret_cast<nv_bfloat16 *>(dlogits_gemm.data_ptr<at::BFloat16>()),
+                        target_i.data_ptr<int>(), grad_f.data_ptr<float>(), lse_f.data_ptr<float>(),
+                        N, vc, logits.stride(0), dlogits_gemm.stride(0),
+                        static_cast<int>(vocab_start_index + v0), false);
+                }
+
+                auto grad_weight_view = grad_weight.narrow(0, v0, vc);
+                if (use_grad_weight_wmma && can_use_grad_weight_tile_wmma(N, D, vc)) {
+                    launch_grad_weight_tile_wmma(dlogits_gemm, hidden_gemm, grad_weight_view);
+                } else {
+                    auto grad_weight_tile =
+                        at::matmul(dlogits_gemm.transpose(0, 1), hidden_gemm);
+                    grad_weight_view.copy_(grad_weight_tile);
+                }
+            }
+            return {empty, grad_weight, empty};
+        }
+
+        auto grad_weight = torch::empty_like(weight);
+        torch::Tensor grad_bias = empty;
+        if (compute_grad_bias)
+            grad_bias = torch::empty({V}, opts_f);
+
+        auto grad_f = grad_logp.reshape({N}).to(torch::kFloat).contiguous();
+        auto lse_f = lse.reshape({N}).to(torch::kFloat).contiguous();
+        auto target_i = target.reshape({N}).to(torch::kInt32).contiguous();
+        torch::Tensor bias_f;
+        const float *bias_ptr = nullptr;
+        if (bias.has_value()) {
+            bias_f = bias->to(torch::kFloat).contiguous();
+            bias_ptr = bias_f.data_ptr<float>();
+        }
+
+        const int blocks = (V + STREAM_BWD_VECS - 1) / STREAM_BWD_VECS;
+        fused_linear_logp_output_only_bwd_stream_kernel<<<
+            blocks, STREAM_BWD_THREADS, 0, at::cuda::getCurrentCUDAStream()>>>(
+            reinterpret_cast<const nv_bfloat16 *>(hidden.data_ptr<at::BFloat16>()),
+            reinterpret_cast<const nv_bfloat16 *>(weight.data_ptr<at::BFloat16>()),
+            target_i.data_ptr<int>(), grad_f.data_ptr<float>(), lse_f.data_ptr<float>(),
+            bias_ptr, reinterpret_cast<nv_bfloat16 *>(grad_weight.data_ptr<at::BFloat16>()),
+            compute_grad_bias ? grad_bias.data_ptr<float>() : nullptr, N, D, V,
+            static_cast<int>(vocab_start_index), bias.has_value(), compute_grad_bias);
+        return {empty, grad_weight, grad_bias};
+    }
+
+    const std::string full_fused_tile_mode = fused_tile_backward_full_grad_mode();
+    if ((full_fused_tile_mode == "tile_cublas" || full_fused_tile_mode == "tile" ||
+         full_fused_tile_mode == "streaming" || full_fused_tile_mode == "tiled") &&
+        (compute_grad_hidden || compute_grad_weight) && !compute_grad_bias &&
+        !bias.has_value() && hidden.scalar_type() == at::kBFloat16 &&
+        weight.scalar_type() == at::kBFloat16 && D % BK == 0) {
+        auto grad_f = grad_logp.reshape({N}).to(torch::kFloat).contiguous();
+        auto lse_f = lse.reshape({N}).to(torch::kFloat).contiguous();
+        auto target_i = target.reshape({N}).to(torch::kInt32).contiguous();
+        auto hidden_gemm = hidden.contiguous();
+        const int tile_v = streaming_output_backward_vocab_tile(V);
+        auto dlogits_workspace = torch::empty({N, tile_v}, hidden.options());
+
+        torch::Tensor grad_hidden = empty;
+        torch::Tensor grad_weight = empty;
+        bool grad_hidden_initialized = false;
+        if (compute_grad_hidden)
+            grad_hidden = torch::empty_like(hidden);
+        if (compute_grad_weight)
+            grad_weight = torch::empty_like(weight);
+
+        for (int v0 = 0; v0 < V; v0 += tile_v) {
+            const int vc = std::min(tile_v, V - v0);
+            auto weight_tile = weight.narrow(0, v0, vc);
+            auto dlogits_gemm = dlogits_workspace.narrow(1, 0, vc);
+            launch_dlogits_tile_bf16_mma(
+                hidden, weight_tile, dlogits_gemm, target_i, grad_f, lse_f,
+                static_cast<int>(vocab_start_index + v0));
+
+            if (compute_grad_hidden) {
+                if (!grad_hidden_initialized) {
+                    at::mm_out(grad_hidden, dlogits_gemm, weight_tile);
+                    grad_hidden_initialized = true;
+                } else {
+                    at::addmm_out(grad_hidden, grad_hidden, dlogits_gemm, weight_tile);
+                }
+            }
+            if (compute_grad_weight) {
+                auto grad_weight_view = grad_weight.narrow(0, v0, vc);
+                at::mm_out(grad_weight_view, dlogits_gemm.transpose(0, 1), hidden_gemm);
+            }
+        }
+        return {grad_hidden, grad_weight, empty};
+    }
+
+    const bool use_input_precision_gemm =
+        fused_backward_use_input_precision_gemm(hidden, weight);
+    const bool use_input_precision_logits = fused_backward_use_input_precision_logits();
+    auto hidden_logits =
+        use_input_precision_logits || hidden.scalar_type() == at::kFloat
+            ? hidden
+            : hidden.to(torch::kFloat).contiguous();
+    auto weight_logits =
+        use_input_precision_logits || weight.scalar_type() == at::kFloat
+            ? weight
+            : weight.to(torch::kFloat).contiguous();
+    auto hidden_grad_gemm =
+        use_input_precision_gemm || hidden.scalar_type() == at::kFloat
+            ? hidden
+            : hidden.to(torch::kFloat).contiguous();
+    auto weight_grad_gemm =
+        use_input_precision_gemm || weight.scalar_type() == at::kFloat
+            ? weight
+            : weight.to(torch::kFloat).contiguous();
+    if (!hidden_logits.is_contiguous())
+        hidden_logits = hidden_logits.contiguous();
+    if (!weight_logits.is_contiguous())
+        weight_logits = weight_logits.contiguous();
+    if (!hidden_grad_gemm.is_contiguous())
+        hidden_grad_gemm = hidden_grad_gemm.contiguous();
+    if (!weight_grad_gemm.is_contiguous())
+        weight_grad_gemm = weight_grad_gemm.contiguous();
+
+    // Recompute local logits once with cuBLAS, then overwrite a fp32 workspace
+    // with dlogits = grad_logp * (onehot(target) - softmax(logits)). For bf16
+    // training, keep the gradient GEMMs in bf16 Tensor Core precision like
+    // native linear backward; only the logits/softmax/dlogits workspace stays
+    // fp32 by default. Set RL_KERNEL_LINEAR_LOGP_FUSED_BWD_PRECISION=input_all
+    // to also recompute logits in input precision.
+    auto logits = at::matmul(hidden_logits, weight_logits.transpose(0, 1)).contiguous();
+    if (bias.has_value()) {
+        auto bias_gemm = bias->to(logits.scalar_type()).contiguous();
+        logits.add_(bias_gemm);
+    }
+
+    auto grad_f = grad_logp.reshape({N}).to(torch::kFloat).contiguous();
+    auto lse_f = lse.reshape({N}).to(torch::kFloat).contiguous();
+    auto target_i = target.reshape({N}).to(torch::kInt32).contiguous();
+    const int threads = 256;
+    const int64_t total = static_cast<int64_t>(N) * V;
+    const int blocks = static_cast<int>((total + threads - 1) / threads);
+    const bool use_rowwise_dlogits =
+        fused_backward_rowwise_dlogits_enabled() && V >= threads;
+    const bool use_bf16_dlogits_gemm =
+        fused_backward_bf16_dlogits_enabled() && use_input_precision_gemm &&
+        hidden.scalar_type() == at::kBFloat16 && weight.scalar_type() == at::kBFloat16 &&
+        logits.scalar_type() == at::kFloat && !compute_grad_bias;
+
+    torch::Tensor dlogits;
+    torch::Tensor dlogits_gemm;
+    torch::Tensor dlogits_source_for_fused_tile;
+    bool dlogits_source_for_fused_tile_are_probs = false;
+    if (use_bf16_dlogits_gemm) {
+        // Default bf16 training path: write the GEMM input directly in bf16.
+        // This skips one full [N,V] fp32->bf16 cast/read/write round trip before
+        // the Tensor Core linear backward GEMMs. Bias grad still uses the older
+        // fp32 dlogits path so its reduction keeps fp32 accumulation.
+        auto dlogits_source =
+            use_global_lse ? logits : at::softmax(logits.to(torch::kFloat), 1).contiguous();
+        dlogits_source_for_fused_tile = dlogits_source;
+        dlogits_source_for_fused_tile_are_probs = !use_global_lse;
+        dlogits_gemm = torch::empty({N, V}, hidden.options());
+        if (use_rowwise_dlogits) {
+            fused_linear_logp_backward_dlogits_bf16_row_kernel<<<
+                N, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+                dlogits_source.data_ptr<float>(),
+                reinterpret_cast<nv_bfloat16 *>(dlogits_gemm.data_ptr<at::BFloat16>()),
+                target_i.data_ptr<int>(), grad_f.data_ptr<float>(), lse_f.data_ptr<float>(), N,
+                V, dlogits_source.stride(0), dlogits_gemm.stride(0),
+                static_cast<int>(vocab_start_index), !use_global_lse);
+        } else {
+            fused_linear_logp_backward_dlogits_bf16_kernel<<<
+                blocks, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+                dlogits_source.data_ptr<float>(),
+                reinterpret_cast<nv_bfloat16 *>(dlogits_gemm.data_ptr<at::BFloat16>()),
+                target_i.data_ptr<int>(), grad_f.data_ptr<float>(), lse_f.data_ptr<float>(), N, V,
+                dlogits_source.stride(0), dlogits_gemm.stride(0),
+                static_cast<int>(vocab_start_index), !use_global_lse);
+        }
+    } else {
+        dlogits = use_global_lse ? logits.to(torch::kFloat).contiguous()
+                                 : at::softmax(logits.to(torch::kFloat), 1).contiguous();
+        if (use_rowwise_dlogits) {
+            fused_linear_logp_backward_dlogits_row_kernel<<<
+                N, threads, 0, at::cuda::getCurrentCUDAStream()>>>(
+                dlogits.data_ptr<float>(), target_i.data_ptr<int>(), grad_f.data_ptr<float>(),
+                lse_f.data_ptr<float>(), N, V, static_cast<int>(vocab_start_index),
+                !use_global_lse);
+        } else {
+            fused_linear_logp_backward_dlogits_kernel<<<blocks, threads, 0,
+                                                        at::cuda::getCurrentCUDAStream()>>>(
+                dlogits.data_ptr<float>(), target_i.data_ptr<int>(), grad_f.data_ptr<float>(),
+                lse_f.data_ptr<float>(), N, V, static_cast<int>(vocab_start_index),
+                !use_global_lse);
+        }
+        dlogits_gemm = use_input_precision_gemm ? dlogits.to(hidden.scalar_type()).contiguous()
+                                                : dlogits;
+    }
+
+    torch::Tensor grad_hidden = empty;
+    torch::Tensor grad_weight = empty;
+    torch::Tensor grad_bias = empty;
+    if (compute_grad_hidden)
+        grad_hidden = at::matmul(dlogits_gemm, weight_grad_gemm);
+    if (compute_grad_weight) {
+        const std::string full_fused_tile_mode = fused_tile_backward_full_grad_mode();
+        const bool use_full_fused_tile_dw =
+            !full_fused_tile_mode.empty() && use_bf16_dlogits_gemm &&
+            hidden_grad_gemm.scalar_type() == at::kBFloat16 &&
+            can_use_grad_weight_tile_wmma(N, D, V);
+        if (use_full_fused_tile_dw) {
+            grad_weight = torch::empty_like(weight);
+            if (full_fused_tile_mode == "from_logits" ||
+                full_fused_tile_mode == "logits" ||
+                full_fused_tile_mode == "recompute") {
+                TORCH_CHECK(dlogits_source_for_fused_tile.defined(),
+                            "from_logits full fused tile requires fp32 logits/probs source");
+                launch_grad_weight_from_logits_tile_wmma(
+                    dlogits_source_for_fused_tile, hidden_grad_gemm, target_i, grad_f, lse_f,
+                    grad_weight, static_cast<int>(vocab_start_index),
+                    dlogits_source_for_fused_tile_are_probs);
+            } else {
+                launch_grad_weight_tile_wmma(dlogits_gemm, hidden_grad_gemm, grad_weight);
+            }
+        } else {
+            grad_weight = at::matmul(dlogits_gemm.transpose(0, 1), hidden_grad_gemm);
+        }
+    }
+    if (compute_grad_bias)
+        grad_bias = dlogits.sum(0);
+
+    return {grad_hidden, grad_weight, grad_bias};
 }

--- a/csrc/cuda/fused_logp_sm90.cu
+++ b/csrc/cuda/fused_logp_sm90.cu
@@ -8,6 +8,12 @@
 
 #define TILE_V 4096
 
+struct MaxOp {
+    __device__ __forceinline__ float operator()(float a, float b) const {
+        return fmaxf(a, b);
+    }
+};
+
 template<int NUM_WARPS>
 __global__ void fused_logp_online_tma_kernel(
     const __grid_constant__ CUtensorMap logits_tmap,
@@ -73,7 +79,7 @@ __global__ void fused_logp_online_tma_kernel(
                 float val = __bfloat162float(smem_logits[i]);
                 tile_max = max(tile_max, val);
             }
-            float block_tile_max = BlockReduce(temp_storage).Reduce(tile_max, cub::Max());
+            float block_tile_max = BlockReduce(temp_storage).Reduce(tile_max, MaxOp{});
             __shared__ float s_tile_max;
             if (consumer_tid == 0) s_tile_max = block_tile_max;
             asm volatile("bar.sync 1, %0;" :: "n"(num_consumers));
@@ -83,7 +89,7 @@ __global__ void fused_logp_online_tma_kernel(
                 float val = __bfloat162float(smem_logits[i]);
                 tile_sum += expf(val - s_tile_max);
             }
-            float block_tile_sum = BlockReduce(temp_storage).Reduce(tile_sum, cub::Sum());
+            float block_tile_sum = BlockReduce(temp_storage).Sum(tile_sum);
             __shared__ float s_tile_sum;
             if (consumer_tid == 0) s_tile_sum = block_tile_sum;
             asm volatile("bar.sync 1, %0;" :: "n"(num_consumers));

--- a/csrc/ops.cpp
+++ b/csrc/ops.cpp
@@ -13,6 +13,51 @@ std::vector<torch::Tensor> fused_linear_logp_sm90_forward(torch::Tensor hidden,
                                                           torch::Tensor weight,
                                                           torch::Tensor target,
                                                           torch::optional<torch::Tensor> bias);
+std::vector<torch::Tensor> fused_linear_logp_sm90_global_target_forward(
+    torch::Tensor hidden,
+    torch::Tensor weight,
+    torch::Tensor target,
+    torch::optional<torch::Tensor> bias,
+    int64_t vocab_start_index);
+std::vector<torch::Tensor> fused_linear_logp_sm90_backward(torch::Tensor grad_logp,
+                                                           torch::Tensor hidden,
+                                                           torch::Tensor weight,
+                                                           torch::Tensor target,
+                                                           torch::Tensor lse,
+                                                           torch::optional<torch::Tensor> bias,
+                                                           int64_t vocab_start_index,
+                                                           bool compute_grad_hidden,
+                                                           bool compute_grad_weight,
+                                                           bool compute_grad_bias,
+                                                           bool use_global_lse);
+std::vector<torch::Tensor> linear_logp_probs_bf16_forward(torch::Tensor logits,
+                                                          torch::Tensor target,
+                                                          int64_t vocab_start_index);
+std::vector<torch::Tensor> linear_logp_bf16_forward(torch::Tensor logits,
+                                                    torch::Tensor target,
+                                                    int64_t vocab_start_index);
+std::vector<torch::Tensor> linear_logp_local_probs_bf16_forward(torch::Tensor logits,
+                                                                torch::Tensor target,
+                                                                int64_t vocab_start_index);
+std::vector<torch::Tensor> linear_logp_local_bf16_forward(torch::Tensor logits,
+                                                          torch::Tensor target,
+                                                          int64_t vocab_start_index);
+torch::Tensor linear_logp_probs_bf16_to_dlogits_(torch::Tensor probs,
+                                                 torch::Tensor target,
+                                                 torch::Tensor grad_logp,
+                                                 int64_t vocab_start_index);
+torch::Tensor linear_logp_local_probs_bf16_to_dlogits_(torch::Tensor probs,
+                                                       torch::Tensor target,
+                                                       torch::Tensor grad_logp,
+                                                       torch::Tensor local_lse,
+                                                       torch::Tensor global_lse,
+                                                       int64_t vocab_start_index);
+torch::Tensor linear_logp_logits_bf16_to_dlogits(torch::Tensor logits,
+                                                 torch::Tensor dlogits,
+                                                 torch::Tensor target,
+                                                 torch::Tensor grad_logp,
+                                                 torch::Tensor lse,
+                                                 int64_t vocab_start_index);
 #endif
 
 #if defined(__CUDACC__) || defined(KERNEL_ALIGN_WITH_CUDA)
@@ -81,6 +126,25 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("fused_logp_sm90", &fused_logp_sm90_forward, "TMA-accelerated Online Softmax Fused LogP");
     m.def("fused_linear_logp_sm90", &fused_linear_logp_sm90_forward,
           "TMA+WGMMA fused linear log-prob (hidden @ W^T -> selected-token logp), SM90");
+    m.def("fused_linear_logp_sm90_global_target", &fused_linear_logp_sm90_global_target_forward,
+          "TMA+WGMMA local-shard target-logit/lse for vocab-parallel linear log-prob, SM90");
+    m.def("fused_linear_logp_sm90_backward", &fused_linear_logp_sm90_backward,
+          "CUDA fused backward for linear log-prob, SM90 backend");
+    m.def("linear_logp_probs_bf16_forward", &linear_logp_probs_bf16_forward,
+          "Build bf16 softmax probabilities and selected log-prob from bf16 logits");
+    m.def("linear_logp_bf16_forward", &linear_logp_bf16_forward,
+          "Build selected log-prob and lse from bf16 logits without saving probabilities");
+    m.def("linear_logp_local_probs_bf16_forward", &linear_logp_local_probs_bf16_forward,
+          "Build local bf16 softmax probabilities, target logits, and lse from bf16 logits");
+    m.def("linear_logp_local_bf16_forward", &linear_logp_local_bf16_forward,
+          "Build local target logits and lse from bf16 logits without saving probabilities");
+    m.def("linear_logp_probs_bf16_to_dlogits_", &linear_logp_probs_bf16_to_dlogits_,
+          "In-place bf16 probs -> dlogits for selected log-prob backward");
+    m.def("linear_logp_local_probs_bf16_to_dlogits_",
+          &linear_logp_local_probs_bf16_to_dlogits_,
+          "In-place local bf16 probs -> TP dlogits for selected log-prob backward");
+    m.def("linear_logp_logits_bf16_to_dlogits", &linear_logp_logits_bf16_to_dlogits,
+          "Build bf16 dlogits from bf16 logits and fp32 lse");
 #endif
 
 #if defined(__CUDACC__) || defined(KERNEL_ALIGN_WITH_CUDA)

--- a/rl_engine/_C.pyi
+++ b/rl_engine/_C.pyi
@@ -4,6 +4,74 @@ import torch
 
 def fused_logp(logits: torch.Tensor, token_ids: torch.Tensor) -> torch.Tensor: ...
 def fused_logp_sm90(logits: torch.Tensor, labels: torch.Tensor) -> torch.Tensor: ...
+def fused_linear_logp_sm90(
+    hidden: torch.Tensor,
+    weight: torch.Tensor,
+    target: torch.Tensor,
+    bias: torch.Tensor | None,
+) -> list[torch.Tensor]: ...
+def fused_linear_logp_sm90_global_target(
+    hidden: torch.Tensor,
+    weight: torch.Tensor,
+    target: torch.Tensor,
+    bias: torch.Tensor | None,
+    vocab_start_index: int,
+) -> list[torch.Tensor]: ...
+def fused_linear_logp_sm90_backward(
+    grad_logp: torch.Tensor,
+    hidden: torch.Tensor,
+    weight: torch.Tensor,
+    target: torch.Tensor,
+    lse: torch.Tensor,
+    bias: torch.Tensor | None,
+    vocab_start_index: int,
+    compute_grad_hidden: bool,
+    compute_grad_weight: bool,
+    compute_grad_bias: bool,
+    use_global_lse: bool,
+) -> list[torch.Tensor]: ...
+def linear_logp_probs_bf16_forward(
+    logits: torch.Tensor,
+    target: torch.Tensor,
+    vocab_start_index: int,
+) -> list[torch.Tensor]: ...
+def linear_logp_bf16_forward(
+    logits: torch.Tensor,
+    target: torch.Tensor,
+    vocab_start_index: int,
+) -> list[torch.Tensor]: ...
+def linear_logp_local_probs_bf16_forward(
+    logits: torch.Tensor,
+    target: torch.Tensor,
+    vocab_start_index: int,
+) -> list[torch.Tensor]: ...
+def linear_logp_local_bf16_forward(
+    logits: torch.Tensor,
+    target: torch.Tensor,
+    vocab_start_index: int,
+) -> list[torch.Tensor]: ...
+def linear_logp_probs_bf16_to_dlogits_(
+    probs: torch.Tensor,
+    target: torch.Tensor,
+    grad_logp: torch.Tensor,
+    vocab_start_index: int,
+) -> torch.Tensor: ...
+def linear_logp_local_probs_bf16_to_dlogits_(
+    probs: torch.Tensor,
+    target: torch.Tensor,
+    grad_logp: torch.Tensor,
+    local_lse: torch.Tensor,
+    global_lse: torch.Tensor,
+    vocab_start_index: int,
+) -> torch.Tensor: ...
+def linear_logp_logits_bf16_to_dlogits(
+    logits: torch.Tensor,
+    dlogits: torch.Tensor,
+    target: torch.Tensor,
+    grad_logp: torch.Tensor,
+    lse: torch.Tensor,
+    vocab_start_index: int,
+) -> torch.Tensor: ...
 def fused_logp_forward_out(
     logits: torch.Tensor,
     token_ids: torch.Tensor,

--- a/rl_engine/kernels/gtest/op_checks.py
+++ b/rl_engine/kernels/gtest/op_checks.py
@@ -154,9 +154,7 @@ def _run_candidate(
     else:
         case_checks = [_run_case(candidate, case, contract) for case in cases]
     total_outputs = sum(len(case.outputs) for case in case_checks)
-    passed_outputs = sum(
-        1 for case in case_checks for output in case.outputs if output.passed
-    )
+    passed_outputs = sum(1 for case in case_checks for output in case.outputs if output.passed)
     pass_rate = float(passed_outputs / total_outputs) if total_outputs else 0.0
     return CandidateReport(
         candidate_name=candidate.name,
@@ -326,15 +324,18 @@ def _backward_grads(
     grad_outputs: list[torch.Tensor],
 ) -> list[torch.Tensor]:
     if len(outputs) != len(grad_outputs):
-        raise ValueError(
-            f"got {len(grad_outputs)} upstream gradients for {len(outputs)} outputs"
-        )
+        raise ValueError(f"got {len(grad_outputs)} upstream gradients for {len(outputs)} outputs")
     # `ones` makes this equivalent to output.sum().backward(); `random` tests a
     # stricter vector-Jacobian product.
-    loss = sum(
+    loss_terms = [
         (output.float() * grad_output.to(device=output.device).float()).sum()
         for output, grad_output in zip(outputs, grad_outputs, strict=True)
-    )
+    ]
+    if not loss_terms:
+        raise ValueError("backward checks require at least one output")
+    loss = loss_terms[0]
+    for term in loss_terms[1:]:
+        loss = loss + term
     loss.backward()
     grads: list[torch.Tensor] = []
     for name in grad_input_names:

--- a/rl_engine/kernels/gtest/operator_inputs.py
+++ b/rl_engine/kernels/gtest/operator_inputs.py
@@ -8,7 +8,6 @@ from typing import Any
 
 import torch
 
-
 DEFAULT_HIDDEN = 4096
 DEFAULT_N_HEADS = 32
 DEFAULT_N_KV_HEADS = 8
@@ -95,9 +94,15 @@ def _make_attention_inputs(
 ) -> dict[str, Any]:
     batch, seq = _batch_seq(args)
     return {
-        "q": _floating_tensor((batch, DEFAULT_N_HEADS, seq, DEFAULT_HEAD_DIM), args, dtype, device, 0),
-        "k": _floating_tensor((batch, DEFAULT_N_KV_HEADS, seq, DEFAULT_HEAD_DIM), args, dtype, device, 1),
-        "v": _floating_tensor((batch, DEFAULT_N_KV_HEADS, seq, DEFAULT_HEAD_DIM), args, dtype, device, 2),
+        "q": _floating_tensor(
+            (batch, DEFAULT_N_HEADS, seq, DEFAULT_HEAD_DIM), args, dtype, device, 0
+        ),
+        "k": _floating_tensor(
+            (batch, DEFAULT_N_KV_HEADS, seq, DEFAULT_HEAD_DIM), args, dtype, device, 1
+        ),
+        "v": _floating_tensor(
+            (batch, DEFAULT_N_KV_HEADS, seq, DEFAULT_HEAD_DIM), args, dtype, device, 2
+        ),
         "causal": True,
     }
 
@@ -132,7 +137,9 @@ def _make_rope_inputs(
 ) -> dict[str, Any]:
     batch, seq = _batch_seq(args)
     return {
-        "x": _floating_tensor((batch, DEFAULT_N_HEADS, seq, DEFAULT_HEAD_DIM), args, dtype, device, 0),
+        "x": _floating_tensor(
+            (batch, DEFAULT_N_HEADS, seq, DEFAULT_HEAD_DIM), args, dtype, device, 0
+        ),
         "positions": torch.arange(seq, device=device, dtype=torch.long),
         "theta": _arg_float(args, "theta", DEFAULT_ROPE_THETA),
     }
@@ -185,11 +192,21 @@ def _make_kv_cache_attention_inputs(
 ) -> dict[str, Any]:
     batch, seq = _batch_seq(args)
     return {
-        "q": _floating_tensor((batch, DEFAULT_N_HEADS, 1, DEFAULT_HEAD_DIM), args, dtype, device, 0),
-        "k_cache": _floating_tensor((batch, DEFAULT_N_KV_HEADS, seq, DEFAULT_HEAD_DIM), args, dtype, device, 1),
-        "v_cache": _floating_tensor((batch, DEFAULT_N_KV_HEADS, seq, DEFAULT_HEAD_DIM), args, dtype, device, 2),
-        "k_new": _floating_tensor((batch, DEFAULT_N_KV_HEADS, 1, DEFAULT_HEAD_DIM), args, dtype, device, 3),
-        "v_new": _floating_tensor((batch, DEFAULT_N_KV_HEADS, 1, DEFAULT_HEAD_DIM), args, dtype, device, 4),
+        "q": _floating_tensor(
+            (batch, DEFAULT_N_HEADS, 1, DEFAULT_HEAD_DIM), args, dtype, device, 0
+        ),
+        "k_cache": _floating_tensor(
+            (batch, DEFAULT_N_KV_HEADS, seq, DEFAULT_HEAD_DIM), args, dtype, device, 1
+        ),
+        "v_cache": _floating_tensor(
+            (batch, DEFAULT_N_KV_HEADS, seq, DEFAULT_HEAD_DIM), args, dtype, device, 2
+        ),
+        "k_new": _floating_tensor(
+            (batch, DEFAULT_N_KV_HEADS, 1, DEFAULT_HEAD_DIM), args, dtype, device, 3
+        ),
+        "v_new": _floating_tensor(
+            (batch, DEFAULT_N_KV_HEADS, 1, DEFAULT_HEAD_DIM), args, dtype, device, 4
+        ),
         "causal": True,
     }
 
@@ -201,7 +218,7 @@ def _floating_tensor(
     device: torch.device,
     offset: int,
 ) -> torch.Tensor:
-    # Example: torch.randn((B, S, V), device="cuda", dtype=torch.bfloat16) 
+    # Example: torch.randn((B, S, V), device="cuda", dtype=torch.bfloat16)
     mode = _arg_str(args, "input_mode", "random")
     if mode == "constant":
         value = _arg_float(args, "constant_value", 0.25) + float(offset) * 0.01

--- a/rl_engine/kernels/gtest/operator_specs.py
+++ b/rl_engine/kernels/gtest/operator_specs.py
@@ -10,8 +10,8 @@ from typing import Any
 
 import torch
 
-from rl_engine.kernels.gtest.operator_inputs import make_operator_inputs, operator_shape_name
 from rl_engine.kernels.gtest.op_checks import CandidateSpec, OperatorCase
+from rl_engine.kernels.gtest.operator_inputs import make_operator_inputs, operator_shape_name
 
 
 @dataclass(frozen=True)

--- a/rl_engine/kernels/gtest/tolerance.py
+++ b/rl_engine/kernels/gtest/tolerance.py
@@ -7,7 +7,6 @@ import json
 from pathlib import Path
 from typing import Any
 
-
 _CONTRACT_PATH = Path(__file__).with_name("tolerance_contract.json")
 
 

--- a/rl_engine/kernels/ops/cuda/loss/linear_logp.py
+++ b/rl_engine/kernels/ops/cuda/loss/linear_logp.py
@@ -3,21 +3,22 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any, Optional
 
 import torch
 
 from rl_engine.kernels.ops.base import _C, _EXT_AVAILABLE
 from rl_engine.kernels.ops.pytorch.loss.linear_logp import (
-    BWD_CHUNK_ELEMS,
-    _linear_logits,
+    _merge_tp_local_logp,
     _require_distributed_initialized,
-    _use_fp32_matmul,
     _validate_global_targets,
-    _validate_tp_vocab_partition,
+    _validate_tp_targets_enabled,
+    _validate_tp_vocab_partition_cached,
     chunked_linear_logp_backward,
     should_use_tensor_parallel_linear_logp,
     tensor_parallel_linear_logp,
+    tensor_parallel_linear_logp_backward,
 )
 from rl_engine.utils.logger import logger
 
@@ -25,20 +26,556 @@ from rl_engine.utils.logger import logger
 # it (mirrors `constexpr int BK` in csrc/cuda/fused_linear_logp_sm90.cu).
 _SM90_BK = 32
 _SM90_TP_PATH_LOGGED = False
+_SM90_FUSED_BWD_PATH_LOGGED = False
+_SM90_SAVE_PROBS_BF16_PATH_LOGGED = False
+_SM90_SAVE_PROBS_BF16_SKIP_LOGGED = False
+_SM90_FUSED_TILE_BF16_PATH_LOGGED = False
+
+
+def _env_disabled(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"0", "false", "no", "off"}
+
+
+def _env_enabled(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _fused_bwd_precision() -> str:
+    return os.getenv("RL_KERNEL_LINEAR_LOGP_FUSED_BWD_PRECISION", "auto").strip().lower()
+
+
+def _sm90_fused_backward_tf32_enabled() -> bool:
+    return (
+        _fused_bwd_precision() != "fp32"
+        and not _env_disabled("RL_KERNEL_LINEAR_LOGP_FUSED_BWD_TF32")
+    )
+
+
+def _sm90_fused_backward_available() -> bool:
+    return (
+        _EXT_AVAILABLE
+        and hasattr(_C, "fused_linear_logp_sm90_backward")
+        and not _env_disabled("RL_KERNEL_LINEAR_LOGP_FUSED_BACKWARD")
+    )
+
+
+def _sm90_global_target_forward_available() -> bool:
+    return _EXT_AVAILABLE and hasattr(_C, "fused_linear_logp_sm90_global_target")
+
+
+def _sm90_save_probs_bf16_available() -> bool:
+    return (
+        _EXT_AVAILABLE
+        and _env_enabled("RL_KERNEL_LINEAR_LOGP_SAVE_PROBS_BF16")
+        and hasattr(_C, "linear_logp_probs_bf16_forward")
+        and hasattr(_C, "linear_logp_probs_bf16_to_dlogits_")
+    )
+
+
+def _sm90_save_probs_bf16_tp_available() -> bool:
+    return (
+        _sm90_save_probs_bf16_available()
+        and hasattr(_C, "linear_logp_local_probs_bf16_forward")
+        and hasattr(_C, "linear_logp_local_probs_bf16_to_dlogits_")
+    )
+
+
+def _sm90_fused_tile_full_enabled() -> bool:
+    value = os.getenv("RL_KERNEL_LINEAR_LOGP_FUSED_TILE_BWD_FULL", "").strip().lower()
+    return value not in {"", "0", "false", "no", "off"}
+
+
+def _sm90_fused_tile_bf16_forward_available(*, tp_path: bool) -> bool:
+    if not (_EXT_AVAILABLE and _sm90_fused_tile_full_enabled()):
+        return False
+    if not _sm90_fused_backward_available():
+        return False
+    if not (
+        hasattr(_C, "linear_logp_bf16_forward")
+        and hasattr(_C, "linear_logp_logits_bf16_to_dlogits")
+    ):
+        return False
+    if tp_path and not hasattr(_C, "linear_logp_local_bf16_forward"):
+        return False
+    return True
+
+
+def _fused_tile_vocab_tile(vocab: int) -> int:
+    raw = os.getenv("RL_KERNEL_LINEAR_LOGP_STREAMING_BWD_VOCAB_TILE")
+    if raw is None or raw.strip() == "":
+        return max(1, vocab)
+    try:
+        tile = int(raw)
+    except ValueError:
+        tile = vocab
+    return max(1, min(tile, vocab))
+
+
+def _log_sm90_save_probs_bf16_skip_once(
+    *, tp_path: bool, details: dict[str, Any] | None = None, **conditions: bool
+) -> None:
+    global _SM90_SAVE_PROBS_BF16_SKIP_LOGGED
+    if _SM90_SAVE_PROBS_BF16_SKIP_LOGGED or not _env_enabled("RL_KERNEL_LINEAR_LOGP_SAVE_PROBS_BF16"):
+        return
+    failed = [name for name, ok in conditions.items() if not ok]
+    logger.info(
+        "save-probs bf16 %slinear_logp fast path not selected; failed=%s conditions=%s details=%s",
+        "tensor-parallel " if tp_path else "",
+        failed,
+        conditions,
+        details,
+    )
+    _SM90_SAVE_PROBS_BF16_SKIP_LOGGED = True
+
+
+def _sm90_linear_logp_backward(
+    grad_logp: torch.Tensor,
+    hidden_2d: torch.Tensor,
+    weight: torch.Tensor,
+    bias_t: torch.Tensor,
+    target_1d: torch.Tensor,
+    lse: torch.Tensor,
+    *,
+    has_bias: bool,
+    lead_shape,
+    hidden_dtype: torch.dtype,
+    weight_dtype: torch.dtype,
+    bias_dtype,
+    vocab_start_index: int = 0,
+    tp_group: Any = None,
+    compute_grad_hidden: bool = True,
+    compute_grad_weight: bool = True,
+    compute_grad_bias: bool = True,
+):
+    global _SM90_FUSED_BWD_PATH_LOGGED
+    if not (compute_grad_hidden or compute_grad_weight or (has_bias and compute_grad_bias)):
+        return None, None, None
+
+    if _sm90_fused_backward_available():
+        if not _SM90_FUSED_BWD_PATH_LOGGED:
+            logger.info("Using fused_linear_logp_sm90_backward fast path.")
+            _SM90_FUSED_BWD_PATH_LOGGED = True
+        prev_allow_tf32 = torch.backends.cuda.matmul.allow_tf32
+        enable_tf32 = _sm90_fused_backward_tf32_enabled()
+        if enable_tf32:
+            torch.backends.cuda.matmul.allow_tf32 = True
+        try:
+            grad_hidden_t, grad_weight_t, grad_bias_t = _C.fused_linear_logp_sm90_backward(
+                grad_logp,
+                hidden_2d,
+                weight,
+                target_1d,
+                lse,
+                bias_t if has_bias else None,
+                int(vocab_start_index),
+                bool(compute_grad_hidden),
+                bool(compute_grad_weight),
+                bool(has_bias and compute_grad_bias),
+                bool(tp_group is not None),
+            )
+        finally:
+            if enable_tf32:
+                torch.backends.cuda.matmul.allow_tf32 = prev_allow_tf32
+        grad_hidden = None
+        if compute_grad_hidden:
+            if tp_group is not None:
+                dist = _require_distributed_initialized()
+                dist.all_reduce(grad_hidden_t, op=dist.ReduceOp.SUM, group=tp_group)
+            grad_hidden = grad_hidden_t.to(hidden_dtype).reshape(
+                (*tuple(lead_shape), hidden_2d.size(1))
+            )
+        grad_weight = grad_weight_t.to(weight_dtype) if compute_grad_weight else None
+        grad_bias = grad_bias_t.to(bias_dtype) if has_bias and compute_grad_bias else None
+        return grad_hidden, grad_weight, grad_bias
+
+    if tp_group is not None:
+        return tensor_parallel_linear_logp_backward(
+            grad_logp,
+            hidden_2d,
+            weight,
+            bias_t,
+            target_1d,
+            lse,
+            has_bias=has_bias,
+            lead_shape=lead_shape,
+            hidden_dtype=hidden_dtype,
+            weight_dtype=weight_dtype,
+            bias_dtype=bias_dtype,
+            vocab_start_index=vocab_start_index,
+            tp_group=tp_group,
+            compute_grad_hidden=compute_grad_hidden,
+            compute_grad_weight=compute_grad_weight,
+            compute_grad_bias=compute_grad_bias,
+        )
+    return chunked_linear_logp_backward(
+        grad_logp,
+        hidden_2d,
+        weight,
+        target_1d,
+        bias_t,
+        has_bias=has_bias,
+        lead_shape=lead_shape,
+        hidden_dtype=hidden_dtype,
+        weight_dtype=weight_dtype,
+        bias_dtype=bias_dtype,
+        compute_grad_hidden=compute_grad_hidden,
+        compute_grad_weight=compute_grad_weight,
+        compute_grad_bias=compute_grad_bias,
+    )
+
+
+class _LinearLogpSaveProbsBF16Function(torch.autograd.Function):
+    """bf16 path that stores softmax probs instead of log-probs.
+
+    It relies on cuBLAS for the linear GEMMs and uses the CUDA helper only for
+    the softmax/probability transforms. When hidden needs gradients, backward
+    also computes ``grad_hidden = dlogits @ weight``.
+    """
+
+    @staticmethod
+    def forward(ctx, hidden, lm_head_weight, target_ids):
+        hidden_2d = hidden.reshape(-1, hidden.size(-1)).contiguous()
+        weight = lm_head_weight.contiguous()
+        target_1d = (
+            target_ids.reshape(-1).to(device=hidden_2d.device, dtype=torch.long).contiguous()
+        )
+        logits = torch.nn.functional.linear(hidden_2d, weight, None)
+        logp, probs = _C.linear_logp_probs_bf16_forward(logits, target_1d, 0)
+        ctx.save_for_backward(probs, hidden_2d, weight, target_1d)
+        ctx.lead_shape = hidden.shape[:-1]
+        return logp.reshape(hidden.shape[:-1])
+
+    @staticmethod
+    def backward(ctx, grad_logp):
+        probs, hidden_2d, weight, target_1d = ctx.saved_tensors
+        grad_hidden = None
+        grad_weight = None
+        if ctx.needs_input_grad[0] or ctx.needs_input_grad[1]:
+            _C.linear_logp_probs_bf16_to_dlogits_(probs, target_1d, grad_logp, 0)
+        if ctx.needs_input_grad[1]:
+            grad_weight = probs.t().matmul(hidden_2d)
+        if ctx.needs_input_grad[0]:
+            grad_hidden = probs.matmul(weight).reshape((*tuple(ctx.lead_shape), weight.size(1)))
+        return grad_hidden, grad_weight, None
+
+
+class _TensorParallelLinearLogpSaveProbsBF16Function(torch.autograd.Function):
+    """TP bf16 path that saves local softmax probs.
+
+    Each rank materializes only its local vocab shard logits/probs. The forward
+    merges local ``target_logit`` and ``lse`` through the shared TP fast merge;
+    backward converts local probs to global dlogits using the saved local/global
+    lse, computes the local shard's ``grad_weight`` with cuBLAS, and all-reduces
+    ``grad_hidden`` when hidden participates in training.
+    """
+
+    @staticmethod
+    def forward(ctx, hidden, lm_head_weight, target_ids, vocab_start_index, global_vocab_size, tp_group):
+        hidden_2d = hidden.reshape(-1, hidden.size(-1)).contiguous()
+        weight = lm_head_weight.contiguous()
+        target_1d = (
+            target_ids.reshape(-1).to(device=hidden_2d.device, dtype=torch.long).contiguous()
+        )
+        vocab_start_index = int(vocab_start_index)
+        global_vocab_size = _validate_tp_vocab_partition_cached(
+            tp_group=tp_group,
+            device=hidden_2d.device,
+            vocab_start_index=vocab_start_index,
+            local_vocab_size=weight.size(0),
+            global_vocab_size=global_vocab_size,
+        )
+        if _validate_tp_targets_enabled():
+            _validate_global_targets(target_1d, global_vocab_size, tp_group)
+
+        logits = torch.nn.functional.linear(hidden_2d, weight, None)
+        local_target_logit, local_lse, probs = _C.linear_logp_local_probs_bf16_forward(
+            logits,
+            target_1d,
+            vocab_start_index,
+        )
+        log_prob, global_lse = _merge_tp_local_logp(
+            local_lse,
+            local_target_logit,
+            tp_group=tp_group,
+        )
+
+        ctx.save_for_backward(probs, hidden_2d, weight, target_1d, local_lse, global_lse)
+        ctx.lead_shape = hidden.shape[:-1]
+        ctx.vocab_start_index = vocab_start_index
+        ctx.tp_group = tp_group
+        return log_prob.reshape(hidden.shape[:-1])
+
+    @staticmethod
+    def backward(ctx, grad_logp):
+        probs, hidden_2d, weight, target_1d, local_lse, global_lse = ctx.saved_tensors
+        grad_hidden = None
+        grad_weight = None
+        if ctx.needs_input_grad[0] or ctx.needs_input_grad[1]:
+            _C.linear_logp_local_probs_bf16_to_dlogits_(
+                probs,
+                target_1d,
+                grad_logp,
+                local_lse,
+                global_lse,
+                ctx.vocab_start_index,
+            )
+        if ctx.needs_input_grad[1]:
+            grad_weight = probs.t().matmul(hidden_2d)
+        if ctx.needs_input_grad[0]:
+            grad_hidden_2d = probs.matmul(weight)
+            dist = _require_distributed_initialized()
+            dist.all_reduce(grad_hidden_2d, op=dist.ReduceOp.SUM, group=ctx.tp_group)
+            grad_hidden = grad_hidden_2d.reshape((*tuple(ctx.lead_shape), weight.size(1)))
+        return grad_hidden, grad_weight, None, None, None, None
+
+
+class _LinearLogpFusedTileBF16Function(torch.autograd.Function):
+    """cuBLAS bf16 logits forward + tiled backward without saving probs."""
+
+    @staticmethod
+    def forward(ctx, hidden, lm_head_weight, target_ids):
+        hidden_2d = hidden.reshape(-1, hidden.size(-1)).contiguous()
+        weight = lm_head_weight.contiguous()
+        target_1d = (
+            target_ids.reshape(-1).to(device=hidden_2d.device, dtype=torch.long).contiguous()
+        )
+        logits = torch.nn.functional.linear(hidden_2d, weight, None)
+        logp, lse = _C.linear_logp_bf16_forward(logits, target_1d, 0)
+        ctx.save_for_backward(logits, hidden_2d, weight, target_1d, lse)
+        ctx.lead_shape = hidden.shape[:-1]
+        ctx.hidden_dtype = hidden.dtype
+        ctx.weight_dtype = lm_head_weight.dtype
+        return logp.reshape(hidden.shape[:-1])
+
+    @staticmethod
+    def backward(ctx, grad_logp):
+        logits, hidden_2d, weight, target_1d, lse = ctx.saved_tensors
+        compute_grad_hidden = ctx.needs_input_grad[0]
+        compute_grad_weight = ctx.needs_input_grad[1]
+        grad_hidden_2d = None
+        grad_weight = None
+        if compute_grad_hidden or compute_grad_weight:
+            n_tokens, vocab = logits.shape
+            tile_v = _fused_tile_vocab_tile(vocab)
+            use_inplace_logits = tile_v >= vocab
+            dlogits_workspace = None
+            if not use_inplace_logits:
+                dlogits_workspace = torch.empty(
+                    (n_tokens, min(tile_v, vocab)),
+                    device=logits.device,
+                    dtype=logits.dtype,
+                )
+            grad_hidden_initialized = False
+            if compute_grad_hidden:
+                grad_hidden_2d = torch.empty_like(hidden_2d)
+            if compute_grad_weight:
+                grad_weight = torch.empty_like(weight)
+            for v0 in range(0, vocab, tile_v):
+                vc = min(tile_v, vocab - v0)
+                logits_tile = logits.narrow(1, v0, vc)
+                if use_inplace_logits:
+                    dlogits_tile = logits_tile
+                else:
+                    dlogits_tile = (
+                        dlogits_workspace
+                        if vc == dlogits_workspace.size(1)
+                        else torch.empty((n_tokens, vc), device=logits.device, dtype=logits.dtype)
+                    )
+                _C.linear_logp_logits_bf16_to_dlogits(
+                    logits_tile,
+                    dlogits_tile,
+                    target_1d,
+                    grad_logp,
+                    lse,
+                    v0,
+                )
+                weight_tile = weight.narrow(0, v0, vc)
+                if compute_grad_hidden:
+                    if not grad_hidden_initialized:
+                        torch.mm(dlogits_tile, weight_tile, out=grad_hidden_2d)
+                        grad_hidden_initialized = True
+                    else:
+                        torch.addmm(
+                            grad_hidden_2d,
+                            dlogits_tile,
+                            weight_tile,
+                            out=grad_hidden_2d,
+                        )
+                if compute_grad_weight:
+                    torch.mm(
+                        dlogits_tile.transpose(0, 1),
+                        hidden_2d,
+                        out=grad_weight.narrow(0, v0, vc),
+                    )
+        grad_hidden = (
+            None
+            if grad_hidden_2d is None
+            else grad_hidden_2d.to(ctx.hidden_dtype).reshape(
+                (*tuple(ctx.lead_shape), hidden_2d.size(1))
+            )
+        )
+        if grad_weight is not None:
+            grad_weight = grad_weight.to(ctx.weight_dtype)
+        return grad_hidden, grad_weight, None
+
+
+class _TensorParallelLinearLogpFusedTileBF16Function(torch.autograd.Function):
+    """TP cuBLAS bf16 logits forward + tiled local backward."""
+
+    @staticmethod
+    def forward(ctx, hidden, lm_head_weight, target_ids, vocab_start_index, global_vocab_size, tp_group):
+        hidden_2d = hidden.reshape(-1, hidden.size(-1)).contiguous()
+        weight = lm_head_weight.contiguous()
+        target_1d = (
+            target_ids.reshape(-1).to(device=hidden_2d.device, dtype=torch.long).contiguous()
+        )
+        vocab_start_index = int(vocab_start_index)
+        global_vocab_size = _validate_tp_vocab_partition_cached(
+            tp_group=tp_group,
+            device=hidden_2d.device,
+            vocab_start_index=vocab_start_index,
+            local_vocab_size=weight.size(0),
+            global_vocab_size=global_vocab_size,
+        )
+        if _validate_tp_targets_enabled():
+            _validate_global_targets(target_1d, global_vocab_size, tp_group)
+
+        logits = torch.nn.functional.linear(hidden_2d, weight, None)
+        local_target_logit, local_lse = _C.linear_logp_local_bf16_forward(
+            logits,
+            target_1d,
+            vocab_start_index,
+        )
+        log_prob, global_lse = _merge_tp_local_logp(
+            local_lse,
+            local_target_logit,
+            tp_group=tp_group,
+        )
+
+        ctx.save_for_backward(logits, hidden_2d, weight, target_1d, global_lse)
+        ctx.lead_shape = hidden.shape[:-1]
+        ctx.hidden_dtype = hidden.dtype
+        ctx.weight_dtype = lm_head_weight.dtype
+        ctx.vocab_start_index = vocab_start_index
+        ctx.tp_group = tp_group
+        return log_prob.reshape(hidden.shape[:-1])
+
+    @staticmethod
+    def backward(ctx, grad_logp):
+        logits, hidden_2d, weight, target_1d, global_lse = ctx.saved_tensors
+        compute_grad_hidden = ctx.needs_input_grad[0]
+        compute_grad_weight = ctx.needs_input_grad[1]
+        grad_hidden_2d = None
+        grad_weight = None
+        if compute_grad_hidden or compute_grad_weight:
+            n_tokens, vocab = logits.shape
+            tile_v = _fused_tile_vocab_tile(vocab)
+            use_inplace_logits = tile_v >= vocab
+            dlogits_workspace = None
+            if not use_inplace_logits:
+                dlogits_workspace = torch.empty(
+                    (n_tokens, min(tile_v, vocab)),
+                    device=logits.device,
+                    dtype=logits.dtype,
+                )
+            grad_hidden_initialized = False
+            if compute_grad_hidden:
+                grad_hidden_2d = torch.empty_like(hidden_2d)
+            if compute_grad_weight:
+                grad_weight = torch.empty_like(weight)
+            for v0 in range(0, vocab, tile_v):
+                vc = min(tile_v, vocab - v0)
+                logits_tile = logits.narrow(1, v0, vc)
+                if use_inplace_logits:
+                    dlogits_tile = logits_tile
+                else:
+                    dlogits_tile = (
+                        dlogits_workspace
+                        if vc == dlogits_workspace.size(1)
+                        else torch.empty((n_tokens, vc), device=logits.device, dtype=logits.dtype)
+                    )
+                _C.linear_logp_logits_bf16_to_dlogits(
+                    logits_tile,
+                    dlogits_tile,
+                    target_1d,
+                    grad_logp,
+                    global_lse,
+                    ctx.vocab_start_index + v0,
+                )
+                weight_tile = weight.narrow(0, v0, vc)
+                if compute_grad_hidden:
+                    if not grad_hidden_initialized:
+                        torch.mm(dlogits_tile, weight_tile, out=grad_hidden_2d)
+                        grad_hidden_initialized = True
+                    else:
+                        torch.addmm(
+                            grad_hidden_2d,
+                            dlogits_tile,
+                            weight_tile,
+                            out=grad_hidden_2d,
+                        )
+                if compute_grad_weight:
+                    torch.mm(
+                        dlogits_tile.transpose(0, 1),
+                        hidden_2d,
+                        out=grad_weight.narrow(0, v0, vc),
+                    )
+        grad_hidden = None
+        if grad_hidden_2d is not None:
+            dist = _require_distributed_initialized()
+            dist.all_reduce(grad_hidden_2d, op=dist.ReduceOp.SUM, group=ctx.tp_group)
+            grad_hidden = grad_hidden_2d.to(ctx.hidden_dtype).reshape(
+                (*tuple(ctx.lead_shape), hidden_2d.size(1))
+            )
+        if grad_weight is not None:
+            grad_weight = grad_weight.to(ctx.weight_dtype)
+        return grad_hidden, grad_weight, None, None, None, None
+
+
+def _sm90_support_details(hidden: torch.Tensor, lm_head_weight: torch.Tensor) -> dict[str, Any]:
+    """Per-condition diagnostics for the bf16 TMA+MMA forward."""
+    same_device = hidden.device == lm_head_weight.device
+    cc_major = None
+    cc_minor = None
+    if hidden.is_cuda:
+        try:
+            cc_major, cc_minor = torch.cuda.get_device_capability(hidden.device)
+        except Exception:
+            pass
+    return {
+        "hidden_is_cuda": hidden.is_cuda,
+        "weight_is_cuda": lm_head_weight.is_cuda,
+        "same_device": same_device,
+        "cc_major_9": cc_major == 9,
+        "hidden_bf16": hidden.dtype == torch.bfloat16,
+        "weight_bf16": lm_head_weight.dtype == torch.bfloat16,
+        "hidden_dim_multiple_32": hidden.size(-1) % _SM90_BK == 0,
+        "hidden_shape": tuple(hidden.shape),
+        "hidden_dtype": str(hidden.dtype),
+        "hidden_device": str(hidden.device),
+        "hidden_requires_grad": bool(hidden.requires_grad),
+        "weight_shape": tuple(lm_head_weight.shape),
+        "weight_dtype": str(lm_head_weight.dtype),
+        "weight_device": str(lm_head_weight.device),
+        "weight_requires_grad": bool(lm_head_weight.requires_grad),
+        "device_capability": None if cc_major is None else (cc_major, cc_minor),
+    }
 
 
 def _sm90_supported(hidden: torch.Tensor, lm_head_weight: torch.Tensor) -> bool:
     """Whether the bf16 TMA+MMA forward can run these inputs directly."""
-    if not (hidden.is_cuda and lm_head_weight.is_cuda):
-        return False
-    if hidden.device != lm_head_weight.device:
-        return False
-    cc_major, _ = torch.cuda.get_device_capability(hidden.device)
-    return (
-        cc_major == 9
-        and hidden.dtype == torch.bfloat16
-        and lm_head_weight.dtype == torch.bfloat16
-        and hidden.size(-1) % _SM90_BK == 0
+    details = _sm90_support_details(hidden, lm_head_weight)
+    return all(
+        bool(details[name])
+        for name in (
+            "hidden_is_cuda",
+            "weight_is_cuda",
+            "same_device",
+            "cc_major_9",
+            "hidden_bf16",
+            "weight_bf16",
+            "hidden_dim_multiple_32",
+        )
     )
 
 
@@ -56,11 +593,12 @@ def _fallback_op():
 
 
 class _FusedLinearLogpSM90Function(torch.autograd.Function):
-    """SM90 TMA+WGMMA fused forward + Liger-style chunked backward.
+    """SM90 TMA+WGMMA fused forward + CUDA fused backward when available.
 
     The forward calls the compiled ``_C.fused_linear_logp_sm90`` kernel (logits
-    never materialized). The backward reuses the deterministic chunked cuBLAS
-    path so gradients flow into ``hidden``, ``lm_head_weight`` and ``bias``.
+    never materialized). The fast backward is a CUDA extension path that
+    materializes local dlogits once and uses GEMMs for the linear gradients,
+    falling back to the deterministic chunked path when unavailable.
     """
 
     @staticmethod
@@ -70,9 +608,15 @@ class _FusedLinearLogpSM90Function(torch.autograd.Function):
         target_1d = (
             target_ids.reshape(-1).to(device=hidden_2d.device, dtype=torch.int32).contiguous()
         )
-        logp, _lse = _C.fused_linear_logp_sm90(hidden_2d, weight, target_1d, bias)
+        logp, lse = _C.fused_linear_logp_sm90(hidden_2d, weight, target_1d, bias)
 
-        ctx.save_for_backward(hidden_2d, weight, bias if bias is not None else hidden_2d, target_1d)
+        ctx.save_for_backward(
+            hidden_2d,
+            weight,
+            bias if bias is not None else hidden_2d,
+            target_1d,
+            lse,
+        )
         ctx.has_bias = bias is not None
         ctx.lead_shape = hidden.shape[:-1]
         ctx.hidden_dtype = hidden.dtype
@@ -82,18 +626,22 @@ class _FusedLinearLogpSM90Function(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_logp):
-        hidden_2d, weight, bias_t, target_1d = ctx.saved_tensors
-        grad_hidden, grad_weight, grad_bias = chunked_linear_logp_backward(
+        hidden_2d, weight, bias_t, target_1d, lse = ctx.saved_tensors
+        grad_hidden, grad_weight, grad_bias = _sm90_linear_logp_backward(
             grad_logp,
             hidden_2d,
             weight,
-            target_1d,
             bias_t,
+            target_1d,
+            lse,
             has_bias=ctx.has_bias,
             lead_shape=ctx.lead_shape,
             hidden_dtype=ctx.hidden_dtype,
             weight_dtype=ctx.weight_dtype,
             bias_dtype=ctx.bias_dtype,
+            compute_grad_hidden=ctx.needs_input_grad[0],
+            compute_grad_weight=ctx.needs_input_grad[1],
+            compute_grad_bias=ctx.needs_input_grad[2],
         )
         # Inputs: hidden, lm_head_weight, bias, target_ids.
         return grad_hidden, grad_weight, grad_bias, None
@@ -105,8 +653,8 @@ class _FusedTensorParallelLinearLogpSM90Function(torch.autograd.Function):
     Each rank runs the fused SM90 kernel over its local vocab shard to get local
     log-sum-exp and the owned target logit. TP ranks then merge those states into
     the global selected log-prob. Backward intentionally reuses the existing
-    chunked TP path so training gradients keep the same contract as the portable
-    implementation.
+    the global selected log-prob. Backward uses the CUDA fused backward fast path
+    when available and otherwise falls back to the portable TP helper.
     """
 
     @staticmethod
@@ -120,8 +668,6 @@ class _FusedTensorParallelLinearLogpSM90Function(torch.autograd.Function):
         global_vocab_size,
         tp_group,
     ):
-        dist = _require_distributed_initialized()
-
         hidden_2d = hidden.reshape(-1, hidden.size(-1)).contiguous()
         weight = lm_head_weight.contiguous()
         target_1d = (
@@ -129,36 +675,47 @@ class _FusedTensorParallelLinearLogpSM90Function(torch.autograd.Function):
         )
         bias_t = bias.contiguous() if bias is not None else hidden_2d
         vocab_start_index = int(vocab_start_index)
-        global_vocab_size = _validate_tp_vocab_partition(
+        global_vocab_size = _validate_tp_vocab_partition_cached(
             tp_group=tp_group,
             device=hidden_2d.device,
             vocab_start_index=vocab_start_index,
             local_vocab_size=weight.size(0),
             global_vocab_size=global_vocab_size,
         )
-        _validate_global_targets(target_1d, global_vocab_size, tp_group)
+        if _validate_tp_targets_enabled():
+            _validate_global_targets(target_1d, global_vocab_size, tp_group)
 
-        local_vocab = weight.size(0)
-        local_target = target_1d - vocab_start_index
-        owns_target = (local_target >= 0) & (local_target < local_vocab)
-        kernel_target = torch.where(local_target >= 0, local_target, torch.zeros_like(local_target))
-        kernel_target = torch.where(
-            kernel_target < local_vocab, kernel_target, torch.zeros_like(kernel_target)
+        if _sm90_global_target_forward_available():
+            local_target_logit, local_lse = _C.fused_linear_logp_sm90_global_target(
+                hidden_2d,
+                weight,
+                target_1d,
+                bias,
+                vocab_start_index,
+            )
+        else:
+            local_vocab = weight.size(0)
+            local_target = target_1d - vocab_start_index
+            owns_target = (local_target >= 0) & (local_target < local_vocab)
+            kernel_target = torch.where(
+                local_target >= 0, local_target, torch.zeros_like(local_target)
+            )
+            kernel_target = torch.where(
+                kernel_target < local_vocab, kernel_target, torch.zeros_like(kernel_target)
+            )
+            kernel_target = kernel_target.to(torch.int32).contiguous()
+
+            local_logp, local_lse = _C.fused_linear_logp_sm90(
+                hidden_2d, weight, kernel_target, bias
+            )
+            local_target_logit = torch.where(
+                owns_target, local_logp + local_lse, torch.zeros_like(local_lse)
+            )
+        log_prob, global_lse = _merge_tp_local_logp(
+            local_lse,
+            local_target_logit,
+            tp_group=tp_group,
         )
-        kernel_target = kernel_target.to(torch.int32).contiguous()
-
-        local_logp, local_lse = _C.fused_linear_logp_sm90(hidden_2d, weight, kernel_target, bias)
-        local_target_logit = torch.where(
-            owns_target, local_logp + local_lse, torch.zeros_like(local_lse)
-        )
-        target_logit = local_target_logit.clone()
-        dist.all_reduce(target_logit, op=dist.ReduceOp.SUM, group=tp_group)
-
-        global_lse_max = local_lse.clone()
-        dist.all_reduce(global_lse_max, op=dist.ReduceOp.MAX, group=tp_group)
-        global_lse_sum = torch.exp(local_lse - global_lse_max)
-        dist.all_reduce(global_lse_sum, op=dist.ReduceOp.SUM, group=tp_group)
-        global_lse = global_lse_max + torch.log(global_lse_sum)
 
         ctx.save_for_backward(hidden_2d, weight, bias_t, target_1d, global_lse)
         ctx.has_bias = bias is not None
@@ -168,59 +725,29 @@ class _FusedTensorParallelLinearLogpSM90Function(torch.autograd.Function):
         ctx.bias_dtype = bias.dtype if bias is not None else None
         ctx.vocab_start_index = vocab_start_index
         ctx.tp_group = tp_group
-        return (target_logit - global_lse).reshape(hidden.shape[:-1])
+        return log_prob.reshape(hidden.shape[:-1])
 
     @staticmethod
     def backward(ctx, grad_logp):
-        dist = _require_distributed_initialized()
         hidden_2d, weight, bias_t, target_1d, global_lse = ctx.saved_tensors
-        n, d = hidden_2d.shape
-        local_vocab = weight.shape[0]
-        dt = weight.dtype
-        g = grad_logp.reshape(-1).to(torch.float32)
-
-        grad_h = torch.empty_like(hidden_2d, dtype=torch.float32)
-        grad_w = torch.zeros(local_vocab, d, device=weight.device, dtype=torch.float32)
-        grad_b = (
-            torch.zeros(local_vocab, device=weight.device, dtype=torch.float32)
-            if ctx.has_bias
-            else None
+        grad_hidden, grad_weight, grad_bias = _sm90_linear_logp_backward(
+            grad_logp,
+            hidden_2d,
+            weight,
+            bias_t,
+            target_1d,
+            global_lse,
+            has_bias=ctx.has_bias,
+            lead_shape=ctx.lead_shape,
+            hidden_dtype=ctx.hidden_dtype,
+            weight_dtype=ctx.weight_dtype,
+            bias_dtype=ctx.bias_dtype,
+            vocab_start_index=ctx.vocab_start_index,
+            tp_group=ctx.tp_group,
+            compute_grad_hidden=ctx.needs_input_grad[0],
+            compute_grad_weight=ctx.needs_input_grad[1],
+            compute_grad_bias=ctx.needs_input_grad[2],
         )
-        use_fp32 = _use_fp32_matmul(hidden_2d, weight)
-
-        chunk = max(1, min(n, BWD_CHUNK_ELEMS // local_vocab))
-        for i0 in range(0, n, chunk):
-            i1 = min(i0 + chunk, n)
-            x = hidden_2d[i0:i1]
-            logits = _linear_logits(
-                x,
-                weight,
-                bias_t if ctx.has_bias else None,
-                use_fp32=use_fp32,
-            )
-
-            dz = -torch.exp(logits.float() - global_lse[i0:i1].unsqueeze(1))
-            local_idx = target_1d[i0:i1] - ctx.vocab_start_index
-            owns_target = (local_idx >= 0) & (local_idx < local_vocab)
-            if bool(owns_target.any().item()):
-                rows = torch.arange(i1 - i0, device=dz.device)[owns_target]
-                dz[rows, local_idx[owns_target].long()] += 1.0
-            dz *= g[i0:i1].unsqueeze(1)
-
-            if use_fp32:
-                grad_h[i0:i1] = torch.matmul(dz, weight.float()).float()
-                grad_w += torch.matmul(dz.t(), x.float()).float()
-            else:
-                dz_dt = dz.to(dt)
-                grad_h[i0:i1] = torch.matmul(dz_dt, weight).float()
-                grad_w += torch.matmul(dz_dt.t(), x).float()
-            if grad_b is not None:
-                grad_b += dz.sum(0)
-
-        dist.all_reduce(grad_h, op=dist.ReduceOp.SUM, group=ctx.tp_group)
-        grad_hidden = grad_h.to(ctx.hidden_dtype).reshape((*ctx.lead_shape, d))
-        grad_weight = grad_w.to(ctx.weight_dtype)
-        grad_bias = grad_b.to(ctx.bias_dtype) if grad_b is not None else None
         return grad_hidden, grad_weight, grad_bias, None, None, None, None
 
 
@@ -297,6 +824,7 @@ class FusedLinearLogpSM90Op:
         vocab_start_index: int = 0,
         global_vocab_size: Optional[int] = None,
     ) -> torch.Tensor:
+        global _SM90_SAVE_PROBS_BF16_PATH_LOGGED, _SM90_FUSED_TILE_BF16_PATH_LOGGED
         if lm_head_weight.size(-1) != hidden.size(-1):
             raise ValueError(
                 f"hidden dim {hidden.size(-1)} must match lm_head_weight dim "
@@ -328,7 +856,69 @@ class FusedLinearLogpSM90Op:
             global_vocab_size,
             lm_head_weight.size(0),
         ):
-            if _sm90_supported(hidden, lm_head_weight):
+            save_probs_tp_available = _sm90_save_probs_bf16_tp_available()
+            sm90_supported = _sm90_supported(hidden, lm_head_weight)
+            bias_none = bias is None
+            hidden_no_grad = not hidden.requires_grad
+            hidden_requires_grad = hidden.requires_grad
+            weight_requires_grad = lm_head_weight.requires_grad
+            any_grad_required = hidden_requires_grad or weight_requires_grad
+            output_only_grad = hidden_no_grad and weight_requires_grad
+            if (
+                save_probs_tp_available
+                and sm90_supported
+                and bias_none
+                and output_only_grad
+            ):
+                if not _SM90_SAVE_PROBS_BF16_PATH_LOGGED:
+                    logger.info(
+                        "Using save-probs bf16 output-only tensor-parallel linear_logp fast path."
+                    )
+                    _SM90_SAVE_PROBS_BF16_PATH_LOGGED = True
+                return _TensorParallelLinearLogpSaveProbsBF16Function.apply(
+                    hidden,
+                    lm_head_weight,
+                    target_ids,
+                    int(vocab_start_index),
+                    None if global_vocab_size is None else int(global_vocab_size),
+                    tp_group,
+                )
+            _log_sm90_save_probs_bf16_skip_once(
+                tp_path=True,
+                details=_sm90_support_details(hidden, lm_head_weight),
+                save_probs_tp_available=save_probs_tp_available,
+                sm90_supported=sm90_supported,
+                bias_none=bias_none,
+                hidden_no_grad=hidden_no_grad,
+                hidden_requires_grad=hidden_requires_grad,
+                weight_requires_grad=weight_requires_grad,
+                any_grad_required=any_grad_required,
+                output_only_grad=output_only_grad,
+            )
+            fused_tile_forward_available = _sm90_fused_tile_bf16_forward_available(
+                tp_path=True
+            )
+            if (
+                fused_tile_forward_available
+                and sm90_supported
+                and bias_none
+                and any_grad_required
+            ):
+                if not _SM90_FUSED_TILE_BF16_PATH_LOGGED:
+                    logger.info(
+                        "Using fused-tile bf16 %stensor-parallel linear_logp fast path.",
+                        "output-only " if hidden_no_grad else "full-gradient ",
+                    )
+                    _SM90_FUSED_TILE_BF16_PATH_LOGGED = True
+                return _TensorParallelLinearLogpFusedTileBF16Function.apply(
+                    hidden,
+                    lm_head_weight,
+                    target_ids,
+                    int(vocab_start_index),
+                    None if global_vocab_size is None else int(global_vocab_size),
+                    tp_group,
+                )
+            if sm90_supported:
                 return _sm90_tensor_parallel_linear_logp(
                     hidden,
                     lm_head_weight,
@@ -356,4 +946,47 @@ class FusedLinearLogpSM90Op:
                 f"target_ids out of range: expected [0, {vocab - 1}], got [{t_min}, {t_max}]. "
                 "Mask or filter padding / ignore-index values (e.g. -100) before this op."
             )
+        save_probs_available = _sm90_save_probs_bf16_available()
+        bias_none = bias is None
+        hidden_no_grad = not hidden.requires_grad
+        hidden_requires_grad = hidden.requires_grad
+        weight_requires_grad = lm_head_weight.requires_grad
+        any_grad_required = hidden_requires_grad or weight_requires_grad
+        if (
+            save_probs_available
+            and bias_none
+            and any_grad_required
+        ):
+            if not _SM90_SAVE_PROBS_BF16_PATH_LOGGED:
+                logger.info(
+                    "Using save-probs bf16 %slinear_logp fast path.",
+                    "output-only " if hidden_no_grad else "full-gradient ",
+                )
+                _SM90_SAVE_PROBS_BF16_PATH_LOGGED = True
+            return _LinearLogpSaveProbsBF16Function.apply(hidden, lm_head_weight, target_ids)
+        _log_sm90_save_probs_bf16_skip_once(
+            tp_path=False,
+            details=_sm90_support_details(hidden, lm_head_weight),
+            save_probs_available=save_probs_available,
+            bias_none=bias_none,
+            hidden_no_grad=hidden_no_grad,
+            hidden_requires_grad=hidden_requires_grad,
+            weight_requires_grad=weight_requires_grad,
+            any_grad_required=any_grad_required,
+        )
+        fused_tile_forward_available = _sm90_fused_tile_bf16_forward_available(
+            tp_path=False
+        )
+        if (
+            fused_tile_forward_available
+            and bias_none
+            and any_grad_required
+        ):
+            if not _SM90_FUSED_TILE_BF16_PATH_LOGGED:
+                logger.info(
+                    "Using fused-tile bf16 %slinear_logp fast path.",
+                    "output-only " if hidden_no_grad else "full-gradient ",
+                )
+                _SM90_FUSED_TILE_BF16_PATH_LOGGED = True
+            return _LinearLogpFusedTileBF16Function.apply(hidden, lm_head_weight, target_ids)
         return _FusedLinearLogpSM90Function.apply(hidden, lm_head_weight, bias, target_ids)

--- a/rl_engine/kernels/ops/cuda/loss/linear_logp.py
+++ b/rl_engine/kernels/ops/cuda/loss/linear_logp.py
@@ -45,9 +45,8 @@ def _fused_bwd_precision() -> str:
 
 
 def _sm90_fused_backward_tf32_enabled() -> bool:
-    return (
-        _fused_bwd_precision() != "fp32"
-        and not _env_disabled("RL_KERNEL_LINEAR_LOGP_FUSED_BWD_TF32")
+    return _fused_bwd_precision() != "fp32" and not _env_disabled(
+        "RL_KERNEL_LINEAR_LOGP_FUSED_BWD_TF32"
     )
 
 
@@ -115,7 +114,9 @@ def _log_sm90_save_probs_bf16_skip_once(
     *, tp_path: bool, details: dict[str, Any] | None = None, **conditions: bool
 ) -> None:
     global _SM90_SAVE_PROBS_BF16_SKIP_LOGGED
-    if _SM90_SAVE_PROBS_BF16_SKIP_LOGGED or not _env_enabled("RL_KERNEL_LINEAR_LOGP_SAVE_PROBS_BF16"):
+    if _SM90_SAVE_PROBS_BF16_SKIP_LOGGED or not _env_enabled(
+        "RL_KERNEL_LINEAR_LOGP_SAVE_PROBS_BF16"
+    ):
         return
     failed = [name for name, ok in conditions.items() if not ok]
     logger.info(
@@ -270,7 +271,9 @@ class _TensorParallelLinearLogpSaveProbsBF16Function(torch.autograd.Function):
     """
 
     @staticmethod
-    def forward(ctx, hidden, lm_head_weight, target_ids, vocab_start_index, global_vocab_size, tp_group):
+    def forward(
+        ctx, hidden, lm_head_weight, target_ids, vocab_start_index, global_vocab_size, tp_group
+    ):
         hidden_2d = hidden.reshape(-1, hidden.size(-1)).contiguous()
         weight = lm_head_weight.contiguous()
         target_1d = (
@@ -423,7 +426,9 @@ class _TensorParallelLinearLogpFusedTileBF16Function(torch.autograd.Function):
     """TP cuBLAS bf16 logits forward + tiled local backward."""
 
     @staticmethod
-    def forward(ctx, hidden, lm_head_weight, target_ids, vocab_start_index, global_vocab_size, tp_group):
+    def forward(
+        ctx, hidden, lm_head_weight, target_ids, vocab_start_index, global_vocab_size, tp_group
+    ):
         hidden_2d = hidden.reshape(-1, hidden.size(-1)).contiguous()
         weight = lm_head_weight.contiguous()
         target_1d = (
@@ -864,12 +869,7 @@ class FusedLinearLogpSM90Op:
             weight_requires_grad = lm_head_weight.requires_grad
             any_grad_required = hidden_requires_grad or weight_requires_grad
             output_only_grad = hidden_no_grad and weight_requires_grad
-            if (
-                save_probs_tp_available
-                and sm90_supported
-                and bias_none
-                and output_only_grad
-            ):
+            if save_probs_tp_available and sm90_supported and bias_none and output_only_grad:
                 if not _SM90_SAVE_PROBS_BF16_PATH_LOGGED:
                     logger.info(
                         "Using save-probs bf16 output-only tensor-parallel linear_logp fast path."
@@ -895,15 +895,8 @@ class FusedLinearLogpSM90Op:
                 any_grad_required=any_grad_required,
                 output_only_grad=output_only_grad,
             )
-            fused_tile_forward_available = _sm90_fused_tile_bf16_forward_available(
-                tp_path=True
-            )
-            if (
-                fused_tile_forward_available
-                and sm90_supported
-                and bias_none
-                and any_grad_required
-            ):
+            fused_tile_forward_available = _sm90_fused_tile_bf16_forward_available(tp_path=True)
+            if fused_tile_forward_available and sm90_supported and bias_none and any_grad_required:
                 if not _SM90_FUSED_TILE_BF16_PATH_LOGGED:
                     logger.info(
                         "Using fused-tile bf16 %stensor-parallel linear_logp fast path.",
@@ -952,11 +945,7 @@ class FusedLinearLogpSM90Op:
         hidden_requires_grad = hidden.requires_grad
         weight_requires_grad = lm_head_weight.requires_grad
         any_grad_required = hidden_requires_grad or weight_requires_grad
-        if (
-            save_probs_available
-            and bias_none
-            and any_grad_required
-        ):
+        if save_probs_available and bias_none and any_grad_required:
             if not _SM90_SAVE_PROBS_BF16_PATH_LOGGED:
                 logger.info(
                     "Using save-probs bf16 %slinear_logp fast path.",
@@ -974,14 +963,8 @@ class FusedLinearLogpSM90Op:
             weight_requires_grad=weight_requires_grad,
             any_grad_required=any_grad_required,
         )
-        fused_tile_forward_available = _sm90_fused_tile_bf16_forward_available(
-            tp_path=False
-        )
-        if (
-            fused_tile_forward_available
-            and bias_none
-            and any_grad_required
-        ):
+        fused_tile_forward_available = _sm90_fused_tile_bf16_forward_available(tp_path=False)
+        if fused_tile_forward_available and bias_none and any_grad_required:
             if not _SM90_FUSED_TILE_BF16_PATH_LOGGED:
                 logger.info(
                     "Using fused-tile bf16 %slinear_logp fast path.",

--- a/rl_engine/kernels/ops/pytorch/loss/linear_logp.py
+++ b/rl_engine/kernels/ops/pytorch/loss/linear_logp.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any, Optional
 
 import torch
@@ -12,6 +13,17 @@ import torch
 # ``N*V``.
 BWD_CHUNK_ELEMS = 1 << 24
 _LOW_PRECISION_DTYPES = (torch.float16, torch.bfloat16)
+_TP_VOCAB_PARTITION_CACHE: dict[tuple[int, str, int, int, Optional[int], int], int] = {}
+
+
+def _env_flag(name: str) -> bool:
+    return os.getenv(name, "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _validate_tp_targets_enabled() -> bool:
+    return _env_flag("RL_KERNEL_LINEAR_LOGP_VALIDATE_TP_TARGETS") or _env_flag(
+        "VIME_RL_KERNEL_VALIDATE_TP_TARGETS"
+    )
 
 
 def _use_fp32_matmul(*tensors: torch.Tensor) -> bool:
@@ -110,7 +122,10 @@ def _validate_tp_vocab_partition(
 
     covered_vocab_size = expected_start
     global_size = torch.tensor(
-        [0, 0 if global_vocab_size is None else int(global_vocab_size)],
+        [
+            1 if global_vocab_size is not None else 0,
+            0 if global_vocab_size is None else int(global_vocab_size),
+        ],
         device=device,
         dtype=torch.long,
     )
@@ -127,6 +142,38 @@ def _validate_tp_vocab_partition(
             f"got {invalid_sizes[0]}, covered {covered_vocab_size}."
         )
     return covered_vocab_size if global_vocab_size is None else int(global_vocab_size)
+
+
+def _validate_tp_vocab_partition_cached(
+    *,
+    tp_group: Any,
+    device: torch.device,
+    vocab_start_index: int,
+    local_vocab_size: int,
+    global_vocab_size: Optional[int],
+) -> int:
+    dist = _require_distributed_initialized()
+    world_size = dist.get_world_size(group=tp_group)
+    key = (
+        id(tp_group),
+        str(device),
+        int(vocab_start_index),
+        int(local_vocab_size),
+        None if global_vocab_size is None else int(global_vocab_size),
+        int(world_size),
+    )
+    cached = _TP_VOCAB_PARTITION_CACHE.get(key)
+    if cached is not None:
+        return cached
+    covered = _validate_tp_vocab_partition(
+        tp_group=tp_group,
+        device=device,
+        vocab_start_index=vocab_start_index,
+        local_vocab_size=local_vocab_size,
+        global_vocab_size=global_vocab_size,
+    )
+    _TP_VOCAB_PARTITION_CACHE[key] = int(covered)
+    return int(covered)
 
 
 def _validate_global_targets(
@@ -172,8 +219,9 @@ def _chunked_local_linear_logp_stats(
     *,
     has_bias: bool,
     vocab_start_index: int,
+    validate_owner_count: bool = False,
     chunk_elems: int = BWD_CHUNK_ELEMS,
-) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor | None]:
     n = hidden_2d.size(0)
     local_vocab = weight.size(0)
     device = hidden_2d.device
@@ -181,7 +229,7 @@ def _chunked_local_linear_logp_stats(
     local_max = torch.full((n,), -torch.inf, device=device, dtype=torch.float32)
     local_sum = torch.zeros(n, device=device, dtype=torch.float32)
     local_target_logit = torch.zeros(n, device=device, dtype=torch.float32)
-    owner_count = torch.zeros(n, device=device, dtype=torch.int32)
+    owner_count = torch.zeros(n, device=device, dtype=torch.int32) if validate_owner_count else None
     rows = torch.arange(n, device=device)
     use_fp32 = _use_fp32_matmul(hidden_2d, weight)
 
@@ -206,12 +254,124 @@ def _chunked_local_linear_logp_stats(
         global_v0 = vocab_start_index + v0
         global_v1 = vocab_start_index + v1
         owns_target = (target_1d >= global_v0) & (target_1d < global_v1)
-        if bool(owns_target.any().item()):
-            local_idx = (target_1d[owns_target] - global_v0).long()
-            local_target_logit[owns_target] = logits_f[rows[owns_target], local_idx]
-            owner_count[owns_target] += 1
+        safe_local_idx = (target_1d - global_v0).clamp(0, max(v1 - v0 - 1, 0)).long()
+        tile_target_logit = logits_f[rows, safe_local_idx]
+        local_target_logit = torch.where(owns_target, tile_target_logit, local_target_logit)
+        if owner_count is not None:
+            owner_count += owns_target.to(torch.int32)
 
     return local_max, local_sum, local_target_logit, owner_count
+
+
+def _merge_tp_local_logp(
+    local_lse: torch.Tensor,
+    local_target_logit: torch.Tensor,
+    *,
+    tp_group: Any,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    dist = _require_distributed_initialized()
+    world_size = dist.get_world_size(group=tp_group)
+    if world_size <= 1:
+        global_lse = local_lse
+        return local_target_logit - global_lse, global_lse
+
+    local_stats = torch.stack((local_lse, local_target_logit), dim=0).contiguous()
+    gathered = torch.empty(
+        (world_size, *local_stats.shape),
+        device=local_stats.device,
+        dtype=local_stats.dtype,
+    )
+    try:
+        dist.all_gather_into_tensor(gathered, local_stats, group=tp_group)
+    except (AttributeError, RuntimeError):
+        chunks = [torch.empty_like(local_stats) for _ in range(world_size)]
+        dist.all_gather(chunks, local_stats, group=tp_group)
+        gathered = torch.stack(chunks, dim=0)
+
+    global_lse = torch.logsumexp(gathered[:, 0, :], dim=0)
+    target_logit = gathered[:, 1, :].sum(dim=0)
+    return target_logit - global_lse, global_lse
+
+
+def tensor_parallel_linear_logp_backward(
+    grad_logp: torch.Tensor,
+    hidden_2d: torch.Tensor,
+    weight: torch.Tensor,
+    bias_t: torch.Tensor,
+    target_1d: torch.Tensor,
+    global_lse: torch.Tensor,
+    *,
+    has_bias: bool,
+    lead_shape,
+    hidden_dtype: torch.dtype,
+    weight_dtype: torch.dtype,
+    bias_dtype,
+    vocab_start_index: int,
+    tp_group: Any,
+    compute_grad_hidden: bool = True,
+    compute_grad_weight: bool = True,
+    compute_grad_bias: bool = True,
+    chunk_elems: int = BWD_CHUNK_ELEMS,
+):
+    dist = _require_distributed_initialized()
+    n, d = hidden_2d.shape
+    local_vocab = weight.shape[0]
+    dt = weight.dtype
+    g = grad_logp.reshape(-1).to(torch.float32)
+
+    grad_h = torch.empty_like(hidden_2d, dtype=torch.float32) if compute_grad_hidden else None
+    grad_w = (
+        torch.zeros(local_vocab, d, device=weight.device, dtype=torch.float32)
+        if compute_grad_weight
+        else None
+    )
+    grad_b = (
+        torch.zeros(local_vocab, device=weight.device, dtype=torch.float32)
+        if has_bias and compute_grad_bias
+        else None
+    )
+    use_fp32 = _use_fp32_matmul(hidden_2d, weight)
+
+    chunk = max(1, min(n, chunk_elems // local_vocab))
+    for i0 in range(0, n, chunk):
+        i1 = min(i0 + chunk, n)
+        x = hidden_2d[i0:i1]
+        logits = _linear_logits(
+            x,
+            weight,
+            bias_t if has_bias else None,
+            use_fp32=use_fp32,
+        )
+
+        dz = -torch.exp(logits.float() - global_lse[i0:i1].unsqueeze(1))
+        local_idx = target_1d[i0:i1] - int(vocab_start_index)
+        owns_target = (local_idx >= 0) & (local_idx < local_vocab)
+        rows = torch.arange(i1 - i0, device=dz.device)
+        safe_local_idx = local_idx.clamp(0, max(local_vocab - 1, 0)).long()
+        dz[rows, safe_local_idx] += owns_target.to(dz.dtype)
+        dz *= g[i0:i1].unsqueeze(1)
+
+        if use_fp32:
+            if grad_h is not None:
+                grad_h[i0:i1] = torch.matmul(dz, weight.float()).float()
+            if grad_w is not None:
+                grad_w += torch.matmul(dz.t(), x.float()).float()
+        else:
+            dz_dt = dz.to(dt)
+            if grad_h is not None:
+                grad_h[i0:i1] = torch.matmul(dz_dt, weight).float()
+            if grad_w is not None:
+                grad_w += torch.matmul(dz_dt.t(), x).float()
+        if grad_b is not None:
+            grad_b += dz.sum(0)
+
+    grad_hidden = None
+    if grad_h is not None:
+        dist.all_reduce(grad_h, op=dist.ReduceOp.SUM, group=tp_group)
+        grad_hidden = grad_h.to(hidden_dtype).reshape((*tuple(lead_shape), d))
+    grad_weight = grad_w.to(weight_dtype) if grad_w is not None else None
+    grad_bias = grad_b.to(bias_dtype) if grad_b is not None else None
+    return grad_hidden, grad_weight, grad_bias
 
 
 class _TensorParallelLinearLogpFunction(torch.autograd.Function):
@@ -228,7 +388,6 @@ class _TensorParallelLinearLogpFunction(torch.autograd.Function):
         global_vocab_size,
         tp_group,
     ):
-        dist = _require_distributed_initialized()
         hidden_2d = hidden.reshape(-1, hidden.size(-1)).contiguous()
         weight = lm_head_weight.contiguous()
         target_1d = (
@@ -236,14 +395,16 @@ class _TensorParallelLinearLogpFunction(torch.autograd.Function):
         )
         bias_t = bias.contiguous() if bias is not None else hidden_2d
         vocab_start_index = int(vocab_start_index)
-        global_vocab_size = _validate_tp_vocab_partition(
+        global_vocab_size = _validate_tp_vocab_partition_cached(
             tp_group=tp_group,
             device=hidden_2d.device,
             vocab_start_index=vocab_start_index,
             local_vocab_size=weight.size(0),
             global_vocab_size=global_vocab_size,
         )
-        _validate_global_targets(target_1d, global_vocab_size, tp_group)
+        validate_tp_targets = _validate_tp_targets_enabled()
+        if validate_tp_targets:
+            _validate_global_targets(target_1d, global_vocab_size, tp_group)
 
         local_max, local_sum, local_target_logit, owner_count = _chunked_local_linear_logp_stats(
             hidden_2d,
@@ -252,25 +413,21 @@ class _TensorParallelLinearLogpFunction(torch.autograd.Function):
             bias_t,
             has_bias=bias is not None,
             vocab_start_index=vocab_start_index,
+            validate_owner_count=validate_tp_targets,
         )
 
-        global_max = local_max.clone()
-        dist.all_reduce(global_max, op=dist.ReduceOp.MAX, group=tp_group)
-        global_sum = local_sum * torch.exp(local_max - global_max)
-        dist.all_reduce(global_sum, op=dist.ReduceOp.SUM, group=tp_group)
+        if owner_count is not None:
+            dist = _require_distributed_initialized()
+            global_owner_count = owner_count.clone()
+            dist.all_reduce(global_owner_count, op=dist.ReduceOp.SUM, group=tp_group)
+            if bool((global_owner_count != 1).any().item()):
+                raise ValueError(
+                    "target_ids must be covered by exactly one TP vocab shard; check "
+                    "vocab_start_index and global_vocab_size."
+                )
 
-        target_logit = local_target_logit.clone()
-        dist.all_reduce(target_logit, op=dist.ReduceOp.SUM, group=tp_group)
-
-        global_owner_count = owner_count.clone()
-        dist.all_reduce(global_owner_count, op=dist.ReduceOp.SUM, group=tp_group)
-        if bool((global_owner_count != 1).any().item()):
-            raise ValueError(
-                "target_ids must be covered by exactly one TP vocab shard; check "
-                "vocab_start_index and global_vocab_size."
-            )
-
-        lse = global_max + torch.log(global_sum)
+        local_lse = local_max + torch.log(local_sum)
+        log_prob, lse = _merge_tp_local_logp(local_lse, local_target_logit, tp_group=tp_group)
         ctx.save_for_backward(hidden_2d, weight, bias_t, target_1d, lse)
         ctx.has_bias = bias is not None
         ctx.lead_shape = hidden.shape[:-1]
@@ -279,59 +436,29 @@ class _TensorParallelLinearLogpFunction(torch.autograd.Function):
         ctx.bias_dtype = bias.dtype if bias is not None else None
         ctx.vocab_start_index = vocab_start_index
         ctx.tp_group = tp_group
-        return (target_logit - lse).reshape(hidden.shape[:-1])
+        return log_prob.reshape(hidden.shape[:-1])
 
     @staticmethod
     def backward(ctx, grad_logp):
-        dist = _require_distributed_initialized()
         hidden_2d, weight, bias_t, target_1d, lse = ctx.saved_tensors
-        n, d = hidden_2d.shape
-        local_vocab = weight.shape[0]
-        dt = weight.dtype
-        g = grad_logp.reshape(-1).to(torch.float32)
-
-        grad_h = torch.empty_like(hidden_2d, dtype=torch.float32)
-        grad_w = torch.zeros(local_vocab, d, device=weight.device, dtype=torch.float32)
-        grad_b = (
-            torch.zeros(local_vocab, device=weight.device, dtype=torch.float32)
-            if ctx.has_bias
-            else None
+        grad_hidden, grad_weight, grad_bias = tensor_parallel_linear_logp_backward(
+            grad_logp,
+            hidden_2d,
+            weight,
+            bias_t,
+            target_1d,
+            lse,
+            has_bias=ctx.has_bias,
+            lead_shape=ctx.lead_shape,
+            hidden_dtype=ctx.hidden_dtype,
+            weight_dtype=ctx.weight_dtype,
+            bias_dtype=ctx.bias_dtype,
+            vocab_start_index=ctx.vocab_start_index,
+            tp_group=ctx.tp_group,
+            compute_grad_hidden=ctx.needs_input_grad[0],
+            compute_grad_weight=ctx.needs_input_grad[1],
+            compute_grad_bias=ctx.needs_input_grad[2],
         )
-        use_fp32 = _use_fp32_matmul(hidden_2d, weight)
-
-        chunk = max(1, min(n, BWD_CHUNK_ELEMS // local_vocab))
-        for i0 in range(0, n, chunk):
-            i1 = min(i0 + chunk, n)
-            x = hidden_2d[i0:i1]
-            logits = _linear_logits(
-                x,
-                weight,
-                bias_t if ctx.has_bias else None,
-                use_fp32=use_fp32,
-            )
-
-            dz = -torch.exp(logits.float() - lse[i0:i1].unsqueeze(1))
-            local_idx = target_1d[i0:i1] - ctx.vocab_start_index
-            owns_target = (local_idx >= 0) & (local_idx < local_vocab)
-            if bool(owns_target.any().item()):
-                rows = torch.arange(i1 - i0, device=dz.device)[owns_target]
-                dz[rows, local_idx[owns_target].long()] += 1.0
-            dz *= g[i0:i1].unsqueeze(1)
-
-            if use_fp32:
-                grad_h[i0:i1] = torch.matmul(dz, weight.float()).float()
-                grad_w += torch.matmul(dz.t(), x.float()).float()
-            else:
-                dz_dt = dz.to(dt)
-                grad_h[i0:i1] = torch.matmul(dz_dt, weight).float()
-                grad_w += torch.matmul(dz_dt.t(), x).float()
-            if grad_b is not None:
-                grad_b += dz.sum(0)
-
-        dist.all_reduce(grad_h, op=dist.ReduceOp.SUM, group=ctx.tp_group)
-        grad_hidden = grad_h.to(ctx.hidden_dtype).reshape((*ctx.lead_shape, d))
-        grad_weight = grad_w.to(ctx.weight_dtype)
-        grad_bias = grad_b.to(ctx.bias_dtype) if grad_b is not None else None
         return grad_hidden, grad_weight, grad_bias, None, None, None, None
 
 
@@ -393,6 +520,9 @@ def chunked_linear_logp_backward(
     weight_dtype: torch.dtype,
     bias_dtype,
     chunk_elems: int = BWD_CHUNK_ELEMS,
+    compute_grad_hidden: bool = True,
+    compute_grad_weight: bool = True,
+    compute_grad_bias: bool = True,
 ):
     # Liger-style chunked backward shared by the Triton and CUDA SM90 fused ops.
     n, d = hidden_2d.shape
@@ -400,9 +530,17 @@ def chunked_linear_logp_backward(
     dt = weight.dtype
     g = grad_logp.reshape(-1).to(torch.float32)
 
-    grad_h = torch.empty_like(hidden_2d, dtype=torch.float32)
-    grad_w = torch.zeros(v, d, device=weight.device, dtype=torch.float32)
-    grad_b = torch.zeros(v, device=weight.device, dtype=torch.float32) if has_bias else None
+    grad_h = torch.empty_like(hidden_2d, dtype=torch.float32) if compute_grad_hidden else None
+    grad_w = (
+        torch.zeros(v, d, device=weight.device, dtype=torch.float32)
+        if compute_grad_weight
+        else None
+    )
+    grad_b = (
+        torch.zeros(v, device=weight.device, dtype=torch.float32)
+        if has_bias and compute_grad_bias
+        else None
+    )
     use_fp32 = _use_fp32_matmul(hidden_2d, weight)
 
     chunk = max(1, min(n, chunk_elems // v))
@@ -424,17 +562,23 @@ def chunked_linear_logp_backward(
         dz *= g[i0:i1].unsqueeze(1)
 
         if use_fp32:
-            grad_h[i0:i1] = torch.matmul(dz, weight.float()).float()  # [C, D]
-            grad_w += torch.matmul(dz.t(), x.float()).float()  # [V, D]
+            if grad_h is not None:
+                grad_h[i0:i1] = torch.matmul(dz, weight.float()).float()  # [C, D]
+            if grad_w is not None:
+                grad_w += torch.matmul(dz.t(), x.float()).float()  # [V, D]
         else:
             dz_dt = dz.to(dt)
-            grad_h[i0:i1] = torch.matmul(dz_dt, weight).float()  # [C, D]
-            grad_w += torch.matmul(dz_dt.t(), x).float()  # [V, D]
+            if grad_h is not None:
+                grad_h[i0:i1] = torch.matmul(dz_dt, weight).float()  # [C, D]
+            if grad_w is not None:
+                grad_w += torch.matmul(dz_dt.t(), x).float()  # [V, D]
         if grad_b is not None:
             grad_b += dz.sum(0)
 
-    grad_hidden = grad_h.to(hidden_dtype).reshape(tuple(lead_shape) + (d,))
-    grad_weight = grad_w.to(weight_dtype)
+    grad_hidden = (
+        grad_h.to(hidden_dtype).reshape(tuple(lead_shape) + (d,)) if grad_h is not None else None
+    )
+    grad_weight = grad_w.to(weight_dtype) if grad_w is not None else None
     grad_bias = grad_b.to(bias_dtype) if grad_b is not None else None
     return grad_hidden, grad_weight, grad_bias
 

--- a/rl_engine/kernels/ops/triton/loss/linear_logp.py
+++ b/rl_engine/kernels/ops/triton/loss/linear_logp.py
@@ -149,6 +149,9 @@ class _LinearLogpFunction(torch.autograd.Function):
             hidden_dtype=ctx.hidden_dtype,
             weight_dtype=ctx.weight_dtype,
             bias_dtype=ctx.bias_dtype,
+            compute_grad_hidden=ctx.needs_input_grad[0],
+            compute_grad_weight=ctx.needs_input_grad[1],
+            compute_grad_bias=ctx.needs_input_grad[2],
         )
         # Inputs: hidden, lm_head_weight, bias, target_ids.
         return grad_hidden, grad_weight, grad_bias, None

--- a/scripts/check_operator.py
+++ b/scripts/check_operator.py
@@ -66,7 +66,9 @@ def _summarize(report: Any) -> None:
 
 
 def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser(description="Validate an operator candidate against a PyTorch gold path.")
+    parser = argparse.ArgumentParser(
+        description="Validate an operator candidate against a PyTorch gold path."
+    )
     parser.add_argument("--op", choices=operator_names(), default="logp")
     parser.add_argument(
         "--candidate",
@@ -92,7 +94,9 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Optional tolerance override key, for example sm90. Defaults to contract.default.",
     )
-    parser.add_argument("--check-grad", action="store_true", help="Also compare gradients for supported inputs.")
+    parser.add_argument(
+        "--check-grad", action="store_true", help="Also compare gradients for supported inputs."
+    )
     # Defaults to random because it catches bugs hidden by output.sum().backward().
     parser.add_argument(
         "--grad-mode",
@@ -101,7 +105,9 @@ def parse_args() -> argparse.Namespace:
         help="Upstream gradient mode used with --check-grad.",
     )
     parser.add_argument("--grad-seed", type=int, default=123, help="Seed for --grad-mode random.")
-    parser.add_argument("--json", action="store_true", help="Print the full structured report as JSON.")
+    parser.add_argument(
+        "--json", action="store_true", help="Print the full structured report as JSON."
+    )
     return parser.parse_args()
 
 

--- a/tests/test_linear_logp.py
+++ b/tests/test_linear_logp.py
@@ -312,6 +312,63 @@ def test_chunked_linear_logp_backward_matches_autograd_and_layout_invariance(use
                 assert torch.allclose(grad_bias, canonical_bias_grad, atol=1e-6)
 
 
+def test_chunked_linear_logp_backward_skips_unused_gradients():
+    hidden, weight, target, bias = _inputs(2029, device="cpu", bias=True)
+    grad_out = torch.randn_like(target, dtype=torch.float32)
+    hidden_2d = hidden.reshape(-1, hidden.size(-1)).contiguous()
+    target_1d = target.reshape(-1).contiguous()
+
+    full_hidden, full_weight, full_bias = chunked_linear_logp_backward(
+        grad_out,
+        hidden_2d,
+        weight,
+        target_1d,
+        bias,
+        has_bias=True,
+        lead_shape=target.shape,
+        hidden_dtype=hidden.dtype,
+        weight_dtype=weight.dtype,
+        bias_dtype=bias.dtype,
+        chunk_elems=weight.size(0) * 3,
+    )
+    skipped_hidden, skipped_weight, skipped_bias = chunked_linear_logp_backward(
+        grad_out,
+        hidden_2d,
+        weight,
+        target_1d,
+        bias,
+        has_bias=True,
+        lead_shape=target.shape,
+        hidden_dtype=hidden.dtype,
+        weight_dtype=weight.dtype,
+        bias_dtype=bias.dtype,
+        chunk_elems=weight.size(0) * 3,
+        compute_grad_hidden=False,
+    )
+    only_hidden, skipped_weight_2, skipped_bias_2 = chunked_linear_logp_backward(
+        grad_out,
+        hidden_2d,
+        weight,
+        target_1d,
+        bias,
+        has_bias=True,
+        lead_shape=target.shape,
+        hidden_dtype=hidden.dtype,
+        weight_dtype=weight.dtype,
+        bias_dtype=bias.dtype,
+        chunk_elems=weight.size(0) * 3,
+        compute_grad_weight=False,
+        compute_grad_bias=False,
+    )
+
+    assert skipped_hidden is None
+    assert torch.allclose(skipped_weight, full_weight, atol=1e-6)
+    assert torch.allclose(skipped_bias, full_bias, atol=1e-6)
+    assert skipped_weight_2 is None
+    assert skipped_bias_2 is None
+    assert torch.allclose(only_hidden, full_hidden, atol=1e-6)
+
+
 def test_tied_embedding_lm_head_shared_gradient_is_layout_invariant():
     torch.manual_seed(2028)
     model = _EmbeddingLMHeadModel(vocab_size=13, hidden_dim=6, bias=False, tie_weights=True)
@@ -532,13 +589,77 @@ def test_sm90_forward_no_bias():
 
 
 @requires_sm90
+def test_sm90_save_probs_bf16_output_only_matches_native(monkeypatch):
+    from rl_engine.kernels.ops.base import _C
+    from rl_engine.kernels.ops.cuda.loss.linear_logp import FusedLinearLogpSM90Op
+
+    if not (
+        hasattr(_C, "linear_logp_probs_bf16_forward")
+        and hasattr(_C, "linear_logp_probs_bf16_to_dlogits_")
+    ):
+        pytest.skip("save-probs bf16 helpers are not compiled into the extension")
+
+    monkeypatch.setenv("RL_KERNEL_LINEAR_LOGP_SAVE_PROBS_BF16", "1")
+    op = FusedLinearLogpSM90Op()
+    hidden, weight, target, _ = _sm90_inputs(136, bias=False)
+    grad_out = torch.randn(_SM90_N, device="cuda")
+
+    h = hidden.detach().clone().requires_grad_(False)
+    w = weight.detach().clone().requires_grad_(True)
+    out = op(h, w, target, None)
+    out.backward(grad_out)
+
+    ref_w = weight.detach().clone().requires_grad_(True)
+    ref_out = NativeLinearLogpOp()(hidden.detach(), ref_w, target, None)
+    ref_out.backward(grad_out)
+
+    assert h.grad is None
+    assert torch.allclose(out.detach(), ref_out.detach(), atol=2e-2)
+    assert torch.allclose(w.grad, ref_w.grad, atol=1.5e-1, rtol=8e-2)
+
+
+@requires_sm90
+def test_sm90_save_probs_bf16_full_gradient_matches_native(monkeypatch):
+    from rl_engine.kernels.ops.base import _C
+    from rl_engine.kernels.ops.cuda.loss.linear_logp import FusedLinearLogpSM90Op
+
+    if not (
+        hasattr(_C, "linear_logp_probs_bf16_forward")
+        and hasattr(_C, "linear_logp_probs_bf16_to_dlogits_")
+    ):
+        pytest.skip("save-probs bf16 helpers are not compiled into the extension")
+
+    monkeypatch.setenv("RL_KERNEL_LINEAR_LOGP_SAVE_PROBS_BF16", "1")
+    op = FusedLinearLogpSM90Op()
+    hidden, weight, target, _ = _sm90_inputs(137, bias=False)
+    grad_out = torch.randn(_SM90_N, device="cuda")
+
+    h = hidden.detach().clone().requires_grad_(True)
+    w = weight.detach().clone().requires_grad_(True)
+    out = op(h, w, target, None)
+    out.backward(grad_out)
+
+    ref_h = hidden.detach().clone().requires_grad_(True)
+    ref_w = weight.detach().clone().requires_grad_(True)
+    ref_out = NativeLinearLogpOp()(ref_h, ref_w, target, None)
+    ref_out.backward(grad_out)
+
+    assert h.grad is not None
+    assert w.grad is not None
+    assert torch.allclose(out.detach(), ref_out.detach(), atol=2e-2)
+    assert torch.allclose(h.grad, ref_h.grad, atol=1.5e-1, rtol=8e-2)
+    assert torch.allclose(w.grad, ref_w.grad, atol=1.5e-1, rtol=8e-2)
+
+
+@requires_sm90
 @pytest.mark.parametrize("use_bias", [True, False])
-def test_sm90_forward_backward_matches_triton(use_bias):
-    # The SM90 forward is fp32-accurate and the backward reuses the same
-    # deterministic chunked path as the Triton op, so both match very tightly.
+def test_sm90_forward_backward_matches_triton(use_bias, monkeypatch):
+    # The strict fp32 backward mode reuses the same deterministic chunked
+    # numerics as the Triton op, so both match very tightly.
     from rl_engine.kernels.ops.cuda.loss.linear_logp import FusedLinearLogpSM90Op
     from rl_engine.kernels.ops.triton.loss.linear_logp import TritonLinearLogpOp
 
+    monkeypatch.setenv("RL_KERNEL_LINEAR_LOGP_FUSED_BWD_PRECISION", "fp32")
     sm90, trit = FusedLinearLogpSM90Op(), TritonLinearLogpOp()
     hidden, weight, target, bias = _sm90_inputs(13, bias=use_bias)
     grad_out = torch.randn(_SM90_N, device="cuda")
@@ -558,6 +679,154 @@ def test_sm90_forward_backward_matches_triton(use_bias):
     assert torch.allclose(sw, tw, atol=2e-3)
     if use_bias:
         assert torch.allclose(sb, tb, atol=2e-3)
+
+
+@requires_sm90
+def test_sm90_default_fast_backward_matches_strict_with_bf16_tolerance(monkeypatch):
+    from rl_engine.kernels.ops.cuda.loss.linear_logp import FusedLinearLogpSM90Op
+
+    op = FusedLinearLogpSM90Op()
+    hidden, weight, target, bias = _sm90_inputs(131, bias=True)
+    grad_out = torch.randn(_SM90_N, device="cuda")
+
+    def run():
+        h = hidden.detach().clone().requires_grad_(True)
+        w = weight.detach().clone().requires_grad_(True)
+        b = bias.detach().clone().requires_grad_(True)
+        out = op(h, w, target, b)
+        out.backward(grad_out)
+        return out.detach(), h.grad, w.grad, b.grad
+
+    monkeypatch.setenv("RL_KERNEL_LINEAR_LOGP_FUSED_BWD_PRECISION", "fp32")
+    strict_out, strict_h, strict_w, strict_b = run()
+    monkeypatch.delenv("RL_KERNEL_LINEAR_LOGP_FUSED_BWD_PRECISION", raising=False)
+    fast_out, fast_h, fast_w, fast_b = run()
+
+    assert torch.allclose(fast_out, strict_out, atol=0.0, rtol=0.0)
+    assert torch.allclose(fast_h, strict_h, atol=8e-2, rtol=8e-2)
+    assert torch.allclose(fast_w, strict_w, atol=8e-2, rtol=8e-2)
+    assert torch.allclose(fast_b, strict_b, atol=2e-3, rtol=2e-3)
+
+
+@requires_sm90
+def test_sm90_bf16_dlogits_fast_path_matches_cast_path(monkeypatch):
+    from rl_engine.kernels.ops.cuda.loss.linear_logp import FusedLinearLogpSM90Op
+
+    op = FusedLinearLogpSM90Op()
+    hidden, weight, target, _ = _sm90_inputs(133, bias=False)
+    grad_out = torch.randn(_SM90_N, device="cuda")
+
+    def run():
+        h = hidden.detach().clone().requires_grad_(True)
+        w = weight.detach().clone().requires_grad_(True)
+        out = op(h, w, target, None)
+        out.backward(grad_out)
+        return out.detach(), h.grad, w.grad
+
+    monkeypatch.setenv("RL_KERNEL_LINEAR_LOGP_FUSED_BWD_BF16_DLOGITS", "0")
+    cast_out, cast_h, cast_w = run()
+    monkeypatch.delenv("RL_KERNEL_LINEAR_LOGP_FUSED_BWD_BF16_DLOGITS", raising=False)
+    fast_out, fast_h, fast_w = run()
+
+    assert torch.allclose(fast_out, cast_out, atol=0.0, rtol=0.0)
+    assert torch.allclose(fast_h, cast_h, atol=0.0, rtol=0.0)
+    assert torch.allclose(fast_w, cast_w, atol=0.0, rtol=0.0)
+
+
+@requires_sm90
+def test_sm90_streaming_output_only_backward_matches_strict(monkeypatch):
+    from rl_engine.kernels.ops.cuda.loss.linear_logp import FusedLinearLogpSM90Op
+
+    op = FusedLinearLogpSM90Op()
+    hidden, weight, target, bias = _sm90_inputs(132, bias=True)
+    grad_out = torch.randn(_SM90_N, device="cuda")
+
+    def run():
+        h = hidden.detach().clone().requires_grad_(False)
+        w = weight.detach().clone().requires_grad_(True)
+        b = bias.detach().clone().requires_grad_(True)
+        out = op(h, w, target, b)
+        out.backward(grad_out)
+        return out.detach(), w.grad, b.grad
+
+    monkeypatch.setenv("RL_KERNEL_LINEAR_LOGP_FUSED_BWD_PRECISION", "fp32")
+    strict_out, strict_w, strict_b = run()
+    monkeypatch.delenv("RL_KERNEL_LINEAR_LOGP_FUSED_BWD_PRECISION", raising=False)
+    monkeypatch.setenv("RL_KERNEL_LINEAR_LOGP_STREAMING_BWD", "1")
+    stream_out, stream_w, stream_b = run()
+
+    assert torch.allclose(stream_out, strict_out, atol=0.0, rtol=0.0)
+    assert torch.allclose(stream_w, strict_w, atol=8e-2, rtol=8e-2)
+    assert torch.allclose(stream_b, strict_b, atol=2e-3, rtol=2e-3)
+
+
+@requires_sm90
+def test_sm90_streaming_tiled_output_only_backward_matches_fast(monkeypatch):
+    from rl_engine.kernels.ops.cuda.loss.linear_logp import FusedLinearLogpSM90Op
+
+    op = FusedLinearLogpSM90Op()
+    hidden, weight, target, _ = _sm90_inputs(134, bias=False)
+    grad_out = torch.randn(_SM90_N, device="cuda")
+
+    def run():
+        h = hidden.detach().clone().requires_grad_(False)
+        w = weight.detach().clone().requires_grad_(True)
+        out = op(h, w, target, None)
+        out.backward(grad_out)
+        return out.detach(), w.grad
+
+    monkeypatch.delenv("RL_KERNEL_LINEAR_LOGP_STREAMING_BWD", raising=False)
+    fast_out, fast_w = run()
+    monkeypatch.setenv("RL_KERNEL_LINEAR_LOGP_STREAMING_BWD", "1")
+    monkeypatch.setenv("RL_KERNEL_LINEAR_LOGP_STREAMING_BWD_VOCAB_TILE", "128")
+    stream_out, stream_w = run()
+
+    assert torch.allclose(stream_out, fast_out, atol=0.0, rtol=0.0)
+    assert torch.allclose(stream_w, fast_w, atol=8e-2, rtol=8e-2)
+
+
+@requires_sm90
+def test_sm90_streaming_tiled_cuda_logits_backward_matches_tiled(monkeypatch):
+    from rl_engine.kernels.ops.cuda.loss.linear_logp import FusedLinearLogpSM90Op
+
+    op = FusedLinearLogpSM90Op()
+    gen = torch.Generator(device="cuda").manual_seed(135)
+    hidden = torch.randn(_SM90_N, _SM90_D, device="cuda", dtype=torch.bfloat16, generator=gen)
+    weight = torch.randn(512, _SM90_D, device="cuda", dtype=torch.bfloat16, generator=gen)
+    target = torch.randint(0, 512, (_SM90_N,), device="cuda", generator=gen)
+    grad_out = torch.randn(_SM90_N, device="cuda", generator=gen)
+
+    def run(logits_mode=None, grad_weight_mode=None):
+        h = hidden.detach().clone().requires_grad_(False)
+        w = weight.detach().clone().requires_grad_(True)
+        monkeypatch.setenv("RL_KERNEL_LINEAR_LOGP_STREAMING_BWD", "1")
+        monkeypatch.setenv("RL_KERNEL_LINEAR_LOGP_STREAMING_BWD_VOCAB_TILE", "128")
+        if logits_mode is not None:
+            monkeypatch.setenv("RL_KERNEL_LINEAR_LOGP_STREAMING_BWD_LOGITS", logits_mode)
+        else:
+            monkeypatch.delenv("RL_KERNEL_LINEAR_LOGP_STREAMING_BWD_LOGITS", raising=False)
+        if grad_weight_mode is not None:
+            monkeypatch.setenv("RL_KERNEL_LINEAR_LOGP_STREAMING_BWD_GW", grad_weight_mode)
+        else:
+            monkeypatch.delenv("RL_KERNEL_LINEAR_LOGP_STREAMING_BWD_GW", raising=False)
+        out = op(h, w, target, None)
+        out.backward(grad_out)
+        return out.detach(), w.grad
+
+    tiled_out, tiled_w = run()
+
+    for logits_mode in ("cuda_tf32", "cuda_bf16_mma", "cuda_bf16_mma_dz"):
+        cuda_out, cuda_w = run(logits_mode)
+        assert torch.allclose(cuda_out, tiled_out, atol=0.0, rtol=0.0)
+        assert torch.allclose(cuda_w, tiled_w, atol=8e-2, rtol=8e-2)
+
+    wmma_out, wmma_w = run("cuda_bf16_mma_dz", "cuda_wmma")
+    assert torch.allclose(wmma_out, tiled_out, atol=0.0, rtol=0.0)
+    assert torch.allclose(wmma_w, tiled_w, atol=8e-2, rtol=8e-2)
+
+    fused_tile_out, fused_tile_w = run("cuda_bf16_mma_dz", "fused_tile")
+    assert torch.allclose(fused_tile_out, tiled_out, atol=0.0, rtol=0.0)
+    assert torch.allclose(fused_tile_w, tiled_w, atol=8e-2, rtol=8e-2)
 
 
 @requires_sm90
@@ -651,6 +920,7 @@ def test_sm90_rejects_out_of_range_target():
 def test_sm90_tp_metadata_prefers_sm90_tp_helper(monkeypatch):
     from rl_engine.kernels.ops.cuda.loss import linear_logp as cuda_linear_logp
 
+    monkeypatch.delenv("RL_KERNEL_LINEAR_LOGP_SAVE_PROBS_BF16", raising=False)
     op = object.__new__(cuda_linear_logp.FusedLinearLogpSM90Op)
     hidden = torch.randn(2, 4)
     weight = torch.randn(3, 4)
@@ -675,6 +945,110 @@ def test_sm90_tp_metadata_prefers_sm90_tp_helper(monkeypatch):
 
     monkeypatch.setattr(cuda_linear_logp, "_sm90_tensor_parallel_linear_logp", fake_sm90_tp)
     monkeypatch.setattr(cuda_linear_logp, "tensor_parallel_linear_logp", forbidden_portable_tp)
+
+    out = op(
+        hidden,
+        weight,
+        target,
+        tp_group=tp_group,
+        vocab_start_index=3,
+        global_vocab_size=6,
+    )
+
+    assert out is sentinel
+    assert calls["sm90_tp"][0] is hidden
+    assert calls["sm90_tp"][1] is weight
+    assert calls["sm90_tp"][2] is target
+    assert calls["sm90_tp"][4] == {
+        "tp_group": tp_group,
+        "vocab_start_index": 3,
+        "global_vocab_size": 6,
+    }
+
+
+def test_sm90_tp_metadata_prefers_save_probs_for_output_only(monkeypatch):
+    from rl_engine.kernels.ops.cuda.loss import linear_logp as cuda_linear_logp
+
+    monkeypatch.setenv("RL_KERNEL_LINEAR_LOGP_SAVE_PROBS_BF16", "1")
+    op = object.__new__(cuda_linear_logp.FusedLinearLogpSM90Op)
+    hidden = torch.randn(2, 4, requires_grad=False)
+    weight = torch.randn(3, 4, requires_grad=True)
+    target = torch.tensor([3, 5])
+    sentinel = torch.full((2,), 11.0)
+    tp_group = object()
+    calls = {}
+
+    monkeypatch.setattr(
+        cuda_linear_logp,
+        "should_use_tensor_parallel_linear_logp",
+        lambda *args, **kwargs: True,
+    )
+    monkeypatch.setattr(cuda_linear_logp, "_sm90_supported", lambda h, w: True)
+    monkeypatch.setattr(cuda_linear_logp, "_sm90_save_probs_bf16_tp_available", lambda: True)
+
+    def fake_save_probs_apply(hidden_arg, weight_arg, target_arg, vocab_start, global_vocab, group):
+        calls["save_probs"] = (hidden_arg, weight_arg, target_arg, vocab_start, global_vocab, group)
+        return sentinel
+
+    def forbidden_sm90_tp(*args, **kwargs):
+        raise AssertionError("regular SM90 TP path should not run when save-probs is available")
+
+    monkeypatch.setattr(
+        cuda_linear_logp._TensorParallelLinearLogpSaveProbsBF16Function,
+        "apply",
+        staticmethod(fake_save_probs_apply),
+    )
+    monkeypatch.setattr(cuda_linear_logp, "_sm90_tensor_parallel_linear_logp", forbidden_sm90_tp)
+
+    out = op(
+        hidden,
+        weight,
+        target,
+        tp_group=tp_group,
+        vocab_start_index=3,
+        global_vocab_size=6,
+    )
+
+    assert out is sentinel
+    assert calls["save_probs"][0] is hidden
+    assert calls["save_probs"][1] is weight
+    assert calls["save_probs"][2] is target
+    assert calls["save_probs"][3:] == (3, 6, tp_group)
+
+
+def test_sm90_tp_metadata_prefers_fused_tp_helper_for_full_gradient(monkeypatch):
+    from rl_engine.kernels.ops.cuda.loss import linear_logp as cuda_linear_logp
+
+    monkeypatch.setenv("RL_KERNEL_LINEAR_LOGP_SAVE_PROBS_BF16", "1")
+    op = object.__new__(cuda_linear_logp.FusedLinearLogpSM90Op)
+    hidden = torch.randn(2, 4, requires_grad=True)
+    weight = torch.randn(3, 4, requires_grad=True)
+    target = torch.tensor([3, 5])
+    sentinel = torch.full((2,), 13.0)
+    tp_group = object()
+    calls = {}
+
+    monkeypatch.setattr(
+        cuda_linear_logp,
+        "should_use_tensor_parallel_linear_logp",
+        lambda *args, **kwargs: True,
+    )
+    monkeypatch.setattr(cuda_linear_logp, "_sm90_supported", lambda h, w: True)
+    monkeypatch.setattr(cuda_linear_logp, "_sm90_save_probs_bf16_tp_available", lambda: True)
+
+    def forbidden_save_probs(*args, **kwargs):
+        raise AssertionError("save-probs TP path should not run for full-gradient training")
+
+    def fake_sm90_tp(hidden_arg, weight_arg, target_arg, bias_arg, **kwargs):
+        calls["sm90_tp"] = (hidden_arg, weight_arg, target_arg, bias_arg, kwargs)
+        return sentinel
+
+    monkeypatch.setattr(
+        cuda_linear_logp._TensorParallelLinearLogpSaveProbsBF16Function,
+        "apply",
+        staticmethod(forbidden_save_probs),
+    )
+    monkeypatch.setattr(cuda_linear_logp, "_sm90_tensor_parallel_linear_logp", fake_sm90_tp)
 
     out = op(
         hidden,
@@ -734,6 +1108,51 @@ def test_sm90_tp_metadata_falls_back_to_portable_tp_when_sm90_unsupported(monkey
     )
 
     assert out is sentinel
+
+
+def test_sm90_backward_prefers_fused_extension_when_available(monkeypatch):
+    from rl_engine.kernels.ops.cuda.loss import linear_logp as cuda_linear_logp
+
+    hidden = torch.randn(4, 6)
+    weight = torch.randn(5, 6)
+    bias = torch.randn(5)
+    target = torch.tensor([0, 1, 2, 3], dtype=torch.long)
+    grad_logp = torch.randn(4)
+    lse = torch.randn(4)
+    calls = {}
+
+    class FakeC:
+        @staticmethod
+        def fused_linear_logp_sm90_backward(*args):
+            calls["backward"] = args
+            return torch.ones_like(hidden), torch.ones_like(weight), torch.ones_like(bias)
+
+    monkeypatch.setattr(cuda_linear_logp, "_EXT_AVAILABLE", True)
+    monkeypatch.setattr(cuda_linear_logp, "_C", FakeC)
+    monkeypatch.delenv("RL_KERNEL_LINEAR_LOGP_FUSED_BACKWARD", raising=False)
+
+    grad_hidden, grad_weight, grad_bias = cuda_linear_logp._sm90_linear_logp_backward(
+        grad_logp,
+        hidden,
+        weight,
+        bias,
+        target,
+        lse,
+        has_bias=True,
+        lead_shape=(4,),
+        hidden_dtype=hidden.dtype,
+        weight_dtype=weight.dtype,
+        bias_dtype=bias.dtype,
+        compute_grad_hidden=False,
+        compute_grad_weight=True,
+        compute_grad_bias=True,
+    )
+
+    assert "backward" in calls
+    assert calls["backward"][7:10] == (False, True, True)
+    assert grad_hidden is None
+    assert torch.equal(grad_weight, torch.ones_like(weight))
+    assert torch.equal(grad_bias, torch.ones_like(bias))
 
 
 def test_registry_dispatch_matches_native():

--- a/tests/test_op_checks.py
+++ b/tests/test_op_checks.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 
 import torch
 
-from rl_engine.kernels.ops.pytorch.loss.logp import NativeLogpOp
 from rl_engine.kernels.gtest.op_checks import CandidateSpec, OperatorCase, run_operator_suite
+from rl_engine.kernels.ops.pytorch.loss.logp import NativeLogpOp
 
 
 def _logp_case(name: str, dtype: torch.dtype, *, seed: int = 0) -> OperatorCase:


### PR DESCRIPTION
## Summary

This PR adds SM90/Hopper fast paths for `linear_logp`, focused on making the training backward path faster instead of only optimizing forward.

Before this change, the SM90 path optimized forward by avoiding materialization of full `[N, V]` logits, but backward still used the portable chunked recompute path. This PR adds fused and optional fast backward paths while keeping fallback behavior available.

## What Changed

- Added SM90 fused `linear_logp` backward support.
- Added tensor-parallel local-shard support for global target ids.
- Added bf16 save-logits / fused-tile full-gradient fast paths.
- Added optional save-probs output-only paths.
- Added optional streaming/tiled backward paths.
- Added dispatch logic to skip unused gradients.
- Added tests for SM90 backward, optional fast paths, and TP dispatch selection.

## Optional Fast Paths

The new performance paths are not all forced by default. They are selected only when the hardware, dtype, shape, gradient requirements, and environment settings match.

Key controls:

- `RL_KERNEL_LINEAR_LOGP_FUSED_BACKWARD=0`
  disables fused backward and falls back to the portable path.
- `RL_KERNEL_LINEAR_LOGP_FUSED_BWD_PRECISION=fp32`
  forces the stricter fp32-style backward path.
- `RL_KERNEL_LINEAR_LOGP_SAVE_PROBS_BF16=1`
  enables save-probs bf16 paths.
- `RL_KERNEL_LINEAR_LOGP_STREAMING_BWD=1`
  enables streaming output-only backward.
- `RL_KERNEL_LINEAR_LOGP_FUSED_TILE_BWD_FULL=...`
  enables fused-tile full-gradient paths.

Benefits of these optional paths:

- **save-probs**: avoids recomputing probabilities in backward, useful when trading memory for speed is acceptable.
- **streaming backward**: reduces workspace pressure for output-layer-only training, especially when `hidden` does not require gradients.
- **tiled backward**: avoids processing the full vocab workspace at once and is useful for large-vocab configurations.
- **fused backward**: reduces Python chunk-loop overhead and improves the main training backward path.

Unsupported or disabled cases still fall back to Triton/PyTorch paths.

## Benchmark Setup

External full-pipeline validation was run with vime + RL-Kernel:

- Model: `Qwen3-30B-A3B`
- GPUs: `8x H100 80GB`
- Parallelism: `TP=2, PP=1, CP=1, EP=8`
- Rollout: full vLLM rollout, no debug rollout
- Number of rollouts: `12`
- Baseline: native output layer + native logprob
- Candidate: RL-Kernel CUDA `linear_logp`
- Candidate target path:
  `Using fused-tile bf16 full-gradient tensor-parallel linear_logp fast path.`
- Fallback count: `0` for completed candidate runs

## Operator-Level Results

The primary comparison is the `linear_logp` operator timing, not end-to-end step time.

| Config | Tokens/call baseline | Tokens/call candidate | Fwd CUDA ms baseline | Fwd CUDA ms candidate | Fwd speedup | Fwd+Bwd CUDA ms baseline | Fwd+Bwd CUDA ms candidate | Fwd+Bwd speedup | Fallback |
| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
| T1 | 796.44 | 796.44 | 5.14 | 3.51 | 1.46x | 15.24 | 12.37 | 1.23x | 0 |
| T2 | 1820.44 | 1820.44 | 7.78 | 3.36 | 2.32x | 18.56 | 10.37 | 1.79x | 0 |
| T3 | 6769.78 | 6826.67 | 14.52 | 7.62 | 1.91x | 33.96 | 18.50 | 1.84x | 0 |

Notes:

- `Fwd+Bwd CUDA ms` is the main timing metric.
- Candidate runs hit the intended fused-tile full-gradient TP path.
- Fallback was `0` in completed candidate runs.
- Baseline had occasional native logprob spikes; stable windows were used for the operator comparison.

## Memory

| Config | Peak VRAM GB baseline | Peak VRAM GB candidate |
| --- | ---: | ---: |
| T1 | 20.60 | 19.89 |
| T2 | 24.14 | 22.49 |
| T3 | 49.26 | 46.23 |

The candidate used less peak reserved memory in all completed full-gradient runs, with the largest completed config reducing peak reserved VRAM by about `3.03 GB`.

## Correctness / Stability

Completed 12-rollout runs passed finite-loss checks.

| Config | Baseline abs diff | Candidate abs diff | Loss finite |
| --- | ---: | ---: | --- |
| T1 | 0.02668 | 0.02537 | pass |
| T2 | 0.02264 | 0.02395 | pass |
| T3 | 0.02034 | 0.02224 | pass |

The absolute logprob difference stayed in the same range as baseline.

## Validation

Local validation:

- `pre-commit run --all-files`
- `mypy --ignore-missing-imports rl_engine/`
- `python -m pytest rl_engine/tests/test_dispatch.py -v`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_attention_correctness.py -q -rs`
- `python -m pytest tests/test_attention.py -v -k "not large and not gpu"`
- `python -m pytest tests/test_kv_cache_attention.py -v -k "not large and not gpu"`
- `python -m pytest tests/test_kernel_registry.py -v`
- `mkdocs build --strict -f mkdocs.yaml`

External metrics source:

`vime/vime-RLK-final-metrics-config-matrix.md`

## Risk and Fallback

This is a performance-oriented SM90 change. The main risks are numeric drift from more aggressive bf16/TF32 paths and the extra complexity of multiple specialized kernels.

Mitigations:

- Optional paths are gated.
- Conservative fallback paths remain available.
- Fused backward can be disabled.
- fp32-style validation mode remains available.
- Unsupported hardware/dtypes/shapes fall back to Triton/PyTorch implementations.