### PR TITLE
Fix blog image paths and remove zh entry from blog nav

### DIFF
--- a/docs/.nav.yml
+++ b/docs/.nav.yml
@@ -3,7 +3,6 @@ nav:
   - Blog:
     - blog/README.md
     - Announcing RL-Kernel for vime: blog/2026-07-08-announcing-rl-kernel-linear-logp-for-vime.md
-    - 中文版：vime + RL-Kernel: blog/2026-07-08-announcing-rl-kernel-linear-logp-for-vime-zh.md
   - User Guide:
     - usage/README.md
     - usage/weight-sync-bridge.md

--- a/docs/blog/2026-07-08-announcing-rl-kernel-linear-logp-for-vime-zh.md
+++ b/docs/blog/2026-07-08-announcing-rl-kernel-linear-logp-for-vime-zh.md
@@ -2,7 +2,7 @@
 layout: post
 title: "发布 vime + RL-Kernel：面向完整 RL Rollout 的更快、更省显存 linear_logp"
 author: "RL-Kernel Contributors and the vime Team"
-image: "../assets/RL-Kernel%20underlying%20operator%20library%20technical%20architecture.png"
+image: "../../assets/RL-Kernel%20underlying%20operator%20library%20technical%20architecture.png"
 summary: "RL-Kernel 将 SM90 tensor-parallel fused linear_logp 接入 vime，在完整 8xH100 rollout 训练中降低单算子 CUDA 时间和单算子显存峰值。"
 read_time_minutes: 7
 tags:
@@ -43,7 +43,7 @@ RL-Kernel 的设计并不是用单一路径覆盖所有场景，而是让 operat
 RL-Kernel 被设计为高层 RL orchestration 和底层 GPU backend 之间的 operator-layer bridge。它通过 custom operator hooks 接入 rollout engines 和 training engines，真正的 kernel 则由 CUDA、Triton、ROCm 以及相关后端实现。
 
 <p align="center">
-<img src="../assets/RL-Kernel%20underlying%20operator%20library%20technical%20architecture.png" alt="RL-Kernel Global Architecture" width="80%">
+<img src="../../assets/RL-Kernel%20underlying%20operator%20library%20technical%20architecture.png" alt="RL-Kernel Global Architecture" width="80%">
 <br>
 <em>RL-Kernel 位于 RL orchestration frameworks 和硬件相关 kernel backends 之间的 operator layer。这里使用的是 RL-Kernel README 中的架构图。</em>
 </p>
@@ -57,7 +57,7 @@ RL-Kernel 被设计为高层 RL orchestration 和底层 GPU backend 之间的 op
 - CUDA extension 直接计算 selected logprob 和 backward 需要的状态，不把完整 `[tokens, vocab]` logits 暴露给 Python framework layer。
 
 <p align="center">
-<img src="../assets/blog/rlk-linear-logp-dataflow.svg" alt="RL-Kernel linear_logp data flow" width="90%">
+<img src="../../assets/blog/rlk-linear-logp-dataflow.svg" alt="RL-Kernel linear_logp data flow" width="90%">
 <br>
 <em>vime 原生路径会物化完整 logits；vime + RL-Kernel 将 selected-logprob 计算融合在 operator layer。</em>
 </p>
@@ -96,7 +96,7 @@ Using fused-tile bf16 full-gradient tensor-parallel linear_logp fast path.
 最强的单算子结果来自 T3：forward + backward CUDA 时间从 **33.96 ms** 降到 **18.50 ms**。T2 的 forward-only speedup 最高，达到 **2.32x**。
 
 <p align="center">
-<img src="../assets/blog/rlk-linear-logp-speedup.svg" alt="RL-Kernel linear_logp fwd+bwd CUDA time speedup" width="90%">
+<img src="../../assets/blog/rlk-linear-logp-speedup.svg" alt="RL-Kernel linear_logp fwd+bwd CUDA time speedup" width="90%">
 <br>
 <em>vime + RL-Kernel 在完成的 no-trace 配置中降低了 forward + backward CUDA 时间。</em>
 </p>
@@ -114,7 +114,7 @@ Using fused-tile bf16 full-gradient tensor-parallel linear_logp fast path.
 T3 是最清晰的单算子显存结果：`linear_logp` operator window 内的 peak reserved delta 从 **32342 MB** 降到 **26710 MB**，节省 **5632 MB**。
 
 <p align="center">
-<img src="../assets/blog/rlk-linear-logp-memory.svg" alt="RL-Kernel linear_logp single-operator memory comparison" width="90%">
+<img src="../../assets/blog/rlk-linear-logp-memory.svg" alt="RL-Kernel linear_logp single-operator memory comparison" width="90%">
 <br>
 <em>显存对比与 timing 对比保持同一口径，都限定在 `linear_logp` 单算子。</em>
 </p>

--- a/docs/blog/2026-07-08-announcing-rl-kernel-linear-logp-for-vime.md
+++ b/docs/blog/2026-07-08-announcing-rl-kernel-linear-logp-for-vime.md
@@ -2,7 +2,7 @@
 layout: post
 title: "Announcing RL-Kernel for vime: Faster and Leaner linear_logp for Full RL Rollouts"
 author: "RL-Kernel Contributors and the vime Team"
-image: "../assets/RL-Kernel%20underlying%20operator%20library%20technical%20architecture.png"
+image: "../../assets/RL-Kernel%20underlying%20operator%20library%20technical%20architecture.png"
 summary: "RL-Kernel brings a fused SM90 tensor-parallel linear_logp operator into vime, cutting selected-logprob CUDA time and peak reserved memory in full 8xH100 rollout training."
 read_time_minutes: 7
 tags:
@@ -43,7 +43,7 @@ RL-Kernel is not designed around a single path for every workload. Instead, oper
 RL-Kernel is designed as an operator-layer bridge between high-level RL orchestration and low-level GPU backends. It integrates with rollout engines and training engines through custom operator hooks, while the actual kernels are implemented through CUDA, Triton, ROCm, and related backend libraries.
 
 <p align="center">
-<img src="../assets/RL-Kernel%20underlying%20operator%20library%20technical%20architecture.png" alt="RL-Kernel Global Architecture" width="80%">
+<img src="../../assets/RL-Kernel%20underlying%20operator%20library%20technical%20architecture.png" alt="RL-Kernel Global Architecture" width="80%">
 <br>
 <em>RL-Kernel sits at the operator layer between RL orchestration frameworks and hardware-specific kernel backends. This is the architecture diagram from the RL-Kernel README.</em>
 </p>
@@ -57,7 +57,7 @@ For `linear_logp`, the vime integration follows this path:
 - The CUDA extension computes selected logprob and the state needed for backward without exposing a full `[tokens, vocab]` logits tensor to the Python framework layer.
 
 <p align="center">
-<img src="../assets/blog/rlk-linear-logp-dataflow.svg" alt="RL-Kernel linear_logp data flow" width="90%">
+<img src="../../assets/blog/rlk-linear-logp-dataflow.svg" alt="RL-Kernel linear_logp data flow" width="90%">
 <br>
 <em>The vime path materializes full logits; the vime + RL-Kernel path fuses selected-logprob computation into the operator layer.</em>
 </p>
@@ -96,7 +96,7 @@ and reported `fallback=0`.
 The strongest single-operator result is T3: the forward plus backward CUDA time drops from **33.96 ms** to **18.50 ms**. T2 shows the best forward-only speedup at **2.32x**.
 
 <p align="center">
-<img src="../assets/blog/rlk-linear-logp-speedup.svg" alt="RL-Kernel linear_logp fwd+bwd CUDA time speedup" width="90%">
+<img src="../../assets/blog/rlk-linear-logp-speedup.svg" alt="RL-Kernel linear_logp fwd+bwd CUDA time speedup" width="90%">
 <br>
 <em>vime + RL-Kernel reduces forward plus backward CUDA time across the completed no-trace configurations.</em>
 </p>
@@ -114,7 +114,7 @@ The memory comparison also uses operator-level probes. It tracks the peak reserv
 T3 is the clearest single-operator memory result: the peak reserved delta drops from **32342 MB** to **26710 MB**, saving **5632 MB** during the `linear_logp` operator window.
 
 <p align="center">
-<img src="../assets/blog/rlk-linear-logp-memory.svg" alt="RL-Kernel linear_logp single-operator memory comparison" width="90%">
+<img src="../../assets/blog/rlk-linear-logp-memory.svg" alt="RL-Kernel linear_logp single-operator memory comparison" width="90%">
 <br>
 <em>The memory comparison is scoped to the `linear_logp` operator, matching the timing comparison.</em>
 </p>

--- a/docs/blog/README.md
+++ b/docs/blog/README.md
@@ -3,4 +3,3 @@
 Release notes and engineering writeups for RL-Kernel.
 
 - [Announcing RL-Kernel for vime: Faster and Leaner `linear_logp` for Full RL Rollouts](2026-07-08-announcing-rl-kernel-linear-logp-for-vime.md)
-- [发布 vime + RL-Kernel：面向完整 RL Rollout 的更快、更省显存 `linear_logp`](2026-07-08-announcing-rl-kernel-linear-logp-for-vime-zh.md)


### PR DESCRIPTION
Fix blog image paths and remove zh entry from blog nav

## Summary
- Fix relative image paths in both vime blog posts so MkDocs resolves assets correctly.
- Remove the Chinese entry from `docs/blog/README.md` and `docs/.nav.yml`.
- Keep the Chinese entry in the root `README.md`.

## Verification
- `mkdocs build -d .tmp_site`
- Confirmed blog pages reference `../../assets/...`
- Confirmed generated blog nav no longer links to the zh post


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated blog navigation to feature the English RL-Kernel announcement.
  - Replaced the Chinese-language blog index entry with the English version.
  - Corrected embedded image paths in both language versions so architecture diagrams, performance charts, and memory comparisons display correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->