### PR TITLE
Musa support native fused logp kernel

### DIFF
--- a/csrc/musa/fused_logp_kernel.mu
+++ b/csrc/musa/fused_logp_kernel.mu
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 RL-Kernel Contributors
+
+#include <musa_runtime.h>
+#include <torch/extension.h>
+#include <torch_musa/csrc/aten/musa/Exceptions.h>
+#include <torch_musa/csrc/aten/musa/MUSAContext.h>
+
+#include <cfloat>
+
+namespace {
+
+constexpr int kBlockSize = 256;
+
+__device__ __forceinline__ float block_reduce_max(float value) {
+    __shared__ float partial[32];
+    const int lane = threadIdx.x & 31;
+    const int warp = threadIdx.x >> 5;
+
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        value = fmaxf(value, __shfl_down_sync(0xffffffffu, value, offset, 32));
+    }
+    if (lane == 0) {
+        partial[warp] = value;
+    }
+    __syncthreads();
+
+    value = threadIdx.x < (kBlockSize / 32) ? partial[lane] : -FLT_MAX;
+    if (warp == 0) {
+#pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1) {
+            value = fmaxf(value, __shfl_down_sync(0xffffffffu, value, offset, 32));
+        }
+    }
+    if (threadIdx.x == 0) {
+        partial[0] = value;
+    }
+    __syncthreads();
+    return partial[0];
+}
+
+__device__ __forceinline__ float block_reduce_sum(float value) {
+    __shared__ float partial[32];
+    const int lane = threadIdx.x & 31;
+    const int warp = threadIdx.x >> 5;
+
+#pragma unroll
+    for (int offset = 16; offset > 0; offset >>= 1) {
+        value += __shfl_down_sync(0xffffffffu, value, offset, 32);
+    }
+    if (lane == 0) {
+        partial[warp] = value;
+    }
+    __syncthreads();
+
+    value = threadIdx.x < (kBlockSize / 32) ? partial[lane] : 0.0f;
+    if (warp == 0) {
+#pragma unroll
+        for (int offset = 16; offset > 0; offset >>= 1) {
+            value += __shfl_down_sync(0xffffffffu, value, offset, 32);
+        }
+    }
+    if (threadIdx.x == 0) {
+        partial[0] = value;
+    }
+    __syncthreads();
+    return partial[0];
+}
+
+template <typename scalar_t>
+__global__ void fused_logp_kernel(
+    const scalar_t* __restrict__ logits,
+    const int64_t* __restrict__ token_ids,
+    scalar_t* __restrict__ output,
+    int rows,
+    int vocab) {
+    const int row = blockIdx.x;
+    if (row >= rows) {
+        return;
+    }
+
+    const scalar_t* row_logits = logits + static_cast<size_t>(row) * vocab;
+    float row_max = -FLT_MAX;
+    for (int col = threadIdx.x; col < vocab; col += blockDim.x) {
+        row_max = fmaxf(row_max, static_cast<float>(row_logits[col]));
+    }
+    row_max = block_reduce_max(row_max);
+
+    float row_sum = 0.0f;
+    for (int col = threadIdx.x; col < vocab; col += blockDim.x) {
+        row_sum += expf(static_cast<float>(row_logits[col]) - row_max);
+    }
+    row_sum = block_reduce_sum(row_sum);
+
+    if (threadIdx.x == 0) {
+        const int64_t target = token_ids[row];
+        const float target_logit = static_cast<float>(row_logits[target]);
+        output[row] = static_cast<scalar_t>(target_logit - row_max - logf(row_sum));
+    }
+}
+
+}  // namespace
+
+torch::Tensor fused_logp_forward_musa(torch::Tensor logits, torch::Tensor token_ids) {
+    auto output = torch::empty({logits.size(0)}, logits.options());
+    const int rows = static_cast<int>(logits.size(0));
+    const int vocab = static_cast<int>(logits.size(1));
+    if (rows == 0) {
+        return output;
+    }
+    auto stream = at::musa::getCurrentMUSAStream();
+
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        at::ScalarType::Half,
+        at::ScalarType::BFloat16,
+        logits.scalar_type(),
+        "musa_fused_logp",
+        [&] {
+            fused_logp_kernel<scalar_t><<<rows, kBlockSize, 0, stream>>>(
+                logits.data_ptr<scalar_t>(),
+                token_ids.data_ptr<int64_t>(),
+                output.data_ptr<scalar_t>(),
+                rows,
+                vocab);
+        });
+    C10_MUSA_KERNEL_LAUNCH_CHECK();
+    return output;
+}

--- a/csrc/musa/fused_logp_kernel.mu
+++ b/csrc/musa/fused_logp_kernel.mu
@@ -100,6 +100,44 @@ __global__ void fused_logp_kernel(
     }
 }
 
+template <typename scalar_t>
+__global__ void fused_logp_backward_kernel(
+    const scalar_t* __restrict__ logits,
+    const int64_t* __restrict__ token_ids,
+    const scalar_t* __restrict__ grad_output,
+    scalar_t* __restrict__ grad_logits,
+    int rows,
+    int vocab) {
+    const int row = blockIdx.x;
+    if (row >= rows) {
+        return;
+    }
+
+    const scalar_t* row_logits = logits + static_cast<size_t>(row) * vocab;
+    scalar_t* row_grad = grad_logits + static_cast<size_t>(row) * vocab;
+
+    float row_max = -FLT_MAX;
+    for (int col = threadIdx.x; col < vocab; col += blockDim.x) {
+        row_max = fmaxf(row_max, static_cast<float>(row_logits[col]));
+    }
+    row_max = block_reduce_max(row_max);
+
+    float row_sum = 0.0f;
+    for (int col = threadIdx.x; col < vocab; col += blockDim.x) {
+        row_sum += expf(static_cast<float>(row_logits[col]) - row_max);
+    }
+    row_sum = block_reduce_sum(row_sum);
+
+    const float upstream = static_cast<float>(grad_output[row]);
+    const int64_t target = token_ids[row];
+    for (int col = threadIdx.x; col < vocab; col += blockDim.x) {
+        const float probability =
+            expf(static_cast<float>(row_logits[col]) - row_max) / row_sum;
+        const float one_hot = col == target ? 1.0f : 0.0f;
+        row_grad[col] = static_cast<scalar_t>(upstream * (one_hot - probability));
+    }
+}
+
 }  // namespace
 
 torch::Tensor fused_logp_forward_musa(torch::Tensor logits, torch::Tensor token_ids) {
@@ -126,4 +164,34 @@ torch::Tensor fused_logp_forward_musa(torch::Tensor logits, torch::Tensor token_
         });
     C10_MUSA_KERNEL_LAUNCH_CHECK();
     return output;
+}
+
+torch::Tensor fused_logp_backward_musa(
+    torch::Tensor logits,
+    torch::Tensor token_ids,
+    torch::Tensor grad_output) {
+    auto grad_logits = torch::empty_like(logits);
+    const int rows = static_cast<int>(logits.size(0));
+    const int vocab = static_cast<int>(logits.size(1));
+    if (rows == 0) {
+        return grad_logits;
+    }
+    auto stream = at::musa::getCurrentMUSAStream();
+
+    AT_DISPATCH_FLOATING_TYPES_AND2(
+        at::ScalarType::Half,
+        at::ScalarType::BFloat16,
+        logits.scalar_type(),
+        "musa_fused_logp_backward",
+        [&] {
+            fused_logp_backward_kernel<scalar_t><<<rows, kBlockSize, 0, stream>>>(
+                logits.data_ptr<scalar_t>(),
+                token_ids.data_ptr<int64_t>(),
+                grad_output.data_ptr<scalar_t>(),
+                grad_logits.data_ptr<scalar_t>(),
+                rows,
+                vocab);
+        });
+    C10_MUSA_KERNEL_LAUNCH_CHECK();
+    return grad_logits;
 }

--- a/csrc/musa/ops.cpp
+++ b/csrc/musa/ops.cpp
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2026 RL-Kernel Contributors
+
+#include <torch/extension.h>
+
+#include <limits>
+
+torch::Tensor fused_logp_forward_musa(torch::Tensor logits, torch::Tensor token_ids);
+
+torch::Tensor fused_logp_forward(torch::Tensor logits, torch::Tensor token_ids) {
+  TORCH_CHECK(logits.device().type() == c10::kPrivateUse1,
+              "logits must be a MUSA tensor, got ", logits.device());
+  TORCH_CHECK(token_ids.device().type() == c10::kPrivateUse1,
+              "token_ids must be a MUSA tensor, got ", token_ids.device());
+  TORCH_CHECK(logits.device() == token_ids.device(),
+              "logits and token_ids must share a device");
+  TORCH_CHECK(logits.dim() == 2, "logits must be a 2D tensor");
+  TORCH_CHECK(token_ids.dim() == 1, "token_ids must be a 1D tensor");
+  TORCH_CHECK(token_ids.scalar_type() == at::ScalarType::Long,
+              "token_ids must be int64");
+  TORCH_CHECK(token_ids.numel() == logits.size(0),
+              "token_ids length must match logits rows");
+  TORCH_CHECK(logits.size(0) <= std::numeric_limits<int>::max(),
+              "too many logits rows");
+  TORCH_CHECK(logits.size(1) > 0, "logits vocabulary dimension must be non-empty");
+  if (token_ids.numel() > 0) {
+    TORCH_CHECK(token_ids.min().item<int64_t>() >= 0 &&
+                    token_ids.max().item<int64_t>() < logits.size(1),
+                "token_ids must be within the logits vocabulary dimension");
+  }
+  TORCH_CHECK(logits.scalar_type() == at::ScalarType::Float ||
+                  logits.scalar_type() == at::ScalarType::Half ||
+                  logits.scalar_type() == at::ScalarType::BFloat16,
+              "MUSA fused_logp supports float32, float16, and bfloat16 logits");
+
+  return fused_logp_forward_musa(logits.contiguous(), token_ids.contiguous());
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+  m.def("fused_logp", &fused_logp_forward,
+        "MUSA fused selected-token log-probability");
+}

--- a/csrc/musa/ops.cpp
+++ b/csrc/musa/ops.cpp
@@ -6,6 +6,8 @@
 #include <limits>
 
 torch::Tensor fused_logp_forward_musa(torch::Tensor logits, torch::Tensor token_ids);
+torch::Tensor fused_logp_backward_musa(
+    torch::Tensor logits, torch::Tensor token_ids, torch::Tensor grad_output);
 
 torch::Tensor fused_logp_forward(torch::Tensor logits, torch::Tensor token_ids) {
   TORCH_CHECK(logits.device().type() == c10::kPrivateUse1,
@@ -36,7 +38,38 @@ torch::Tensor fused_logp_forward(torch::Tensor logits, torch::Tensor token_ids) 
   return fused_logp_forward_musa(logits.contiguous(), token_ids.contiguous());
 }
 
+torch::Tensor fused_logp_backward(
+    torch::Tensor logits,
+    torch::Tensor token_ids,
+    torch::Tensor grad_output) {
+  TORCH_CHECK(logits.device().type() == c10::kPrivateUse1,
+              "logits must be a MUSA tensor, got ", logits.device());
+  TORCH_CHECK(token_ids.device() == logits.device() &&
+                  grad_output.device() == logits.device(),
+              "all tensors must share the same MUSA device");
+  TORCH_CHECK(logits.dim() == 2 && token_ids.dim() == 1 &&
+                  grad_output.dim() == 1,
+              "expected logits [rows, vocab], token_ids [rows], and grad_output [rows]");
+  TORCH_CHECK(token_ids.scalar_type() == at::ScalarType::Long,
+              "token_ids must be int64");
+  TORCH_CHECK(grad_output.scalar_type() == logits.scalar_type(),
+              "grad_output dtype must match logits dtype");
+  TORCH_CHECK(token_ids.numel() == logits.size(0) &&
+                  grad_output.numel() == logits.size(0),
+              "token_ids and grad_output length must match logits rows");
+  TORCH_CHECK(logits.size(1) > 0, "logits vocabulary dimension must be non-empty");
+  if (token_ids.numel() > 0) {
+    TORCH_CHECK(token_ids.min().item<int64_t>() >= 0 &&
+                    token_ids.max().item<int64_t>() < logits.size(1),
+                "token_ids must be within the logits vocabulary dimension");
+  }
+  return fused_logp_backward_musa(
+      logits.contiguous(), token_ids.contiguous(), grad_output.contiguous());
+}
+
 PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
   m.def("fused_logp", &fused_logp_forward,
         "MUSA fused selected-token log-probability");
+  m.def("fused_logp_backward", &fused_logp_backward,
+        "MUSA fused selected-token log-probability backward");
 }

--- a/rl_engine/kernels/ops/cuda/loss/logp.py
+++ b/rl_engine/kernels/ops/cuda/loss/logp.py
@@ -24,6 +24,7 @@ class _FusedLogpAutograd(torch.autograd.Function):
         labels = token_ids.reshape(-1).to(device=logits.device, dtype=torch.long).contiguous()
         output = backend.fused_logp(logits_2d, labels)
         ctx.save_for_backward(logits_2d, labels)
+        ctx.backend = backend
         ctx.input_shape = tuple(logits.shape)
         ctx.input_dtype = logits.dtype
         return output.reshape(logits.shape[:-1])
@@ -31,6 +32,17 @@ class _FusedLogpAutograd(torch.autograd.Function):
     @staticmethod
     def backward(ctx, grad_output: torch.Tensor):
         logits, labels = ctx.saved_tensors
+        if (
+            logits.device.type == "musa"
+            and hasattr(ctx.backend, "fused_logp_backward")
+        ):
+            grad = ctx.backend.fused_logp_backward(
+                logits,
+                labels,
+                grad_output.reshape(-1).contiguous(),
+            )
+            return grad.reshape(ctx.input_shape), None, None
+
         probs = torch.softmax(logits.float(), dim=-1)
         rows = torch.arange(logits.size(0), device=logits.device)
         probs[rows, labels] -= 1.0

--- a/rl_engine/kernels/registry.py
+++ b/rl_engine/kernels/registry.py
@@ -61,6 +61,7 @@ class OpBackend(Enum, metaclass=_KernelEnumMeta):
     # TMA-accelerated LogP for SM90+ (Warp Specialization)
     CUDA_FUSED_LOGP_SM90 = "rl_engine.kernels.ops.cuda.loss.logp.FusedLogpSM90Op"
     CUDA_FUSED_LOGP_GENERIC = "rl_engine.kernels.ops.cuda.loss.logp.FusedLogpGenericOp"
+    MUSA_FUSED_LOGP_GENERIC = "rl_engine.kernels.ops.cuda.loss.logp.FusedLogpGenericOp"
     CUDA_DETERMINISTIC_LOGP = "rl_engine.kernels.ops.cuda.loss.logp.DeterministicLogpCUDAOp"
     # Deterministic standard-softmax attention (issue #147); not FlashAttention.
     CUDA_DETERMINISTIC_ATTENTION = (
@@ -564,7 +565,7 @@ class KernelRegistry:
                 "swiglu": [OpBackend.TRITON_SWIGLU, OpBackend.PYTORCH_NATIVE_SWIGLU],
             },
             "musa": {
-                "logp": [OpBackend.PYTORCH_NATIVE],
+                "logp": [OpBackend.MUSA_FUSED_LOGP_GENERIC, OpBackend.PYTORCH_NATIVE],
                 "logp_indexed": [OpBackend.PYTORCH_NATIVE],
                 "logp_online": [OpBackend.PYTORCH_NATIVE],
                 "logp_online_indexed": [OpBackend.PYTORCH_NATIVE],

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,19 @@ def _load_envs_module():
 
 envs = _load_envs_module()
 
+def _musa_build_available(torch) -> bool:
+    try:
+        import torch_musa  # noqa: F401
+    except ImportError:
+        return False
+    return bool(
+        hasattr(torch, "musa")
+        and (
+            torch.musa.is_available()
+            or bool(os.environ.get("TORCH_MUSA_ARCH_LIST", "").strip())
+        )
+    )
+
 
 def _load_torch_extension_tools():
     try:
@@ -30,6 +43,10 @@ def _load_torch_extension_tools():
             raise
         return None, None, None
 
+    if _musa_build_available(torch):
+        from torch_musa.utils.musa_extension import BuildExtension, MUSAExtension
+
+        return torch, BuildExtension, MUSAExtension
     from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 
     # CUDAExtension is also the supported extension entry point for ROCm
@@ -45,6 +62,8 @@ def _native_extension_required() -> bool:
         or bool(os.environ.get("PYTORCH_ROCM_ARCH", "").strip())
         or bool(os.environ.get("TORCH_CUDA_ARCH_LIST", "").strip())
         or envs.env_flag("FORCE_CUDA")
+        or bool(os.environ.get("TORCH_MUSA_ARCH_LIST", "").strip())
+        or envs.env_flag("FORCE_MUSA")
     )
 
 
@@ -93,7 +112,7 @@ def _filter_rocm_incompatible_nvcc_flags(flags: list[str]) -> list[str]:
 
 
 def get_extensions():
-    torch, _, CUDAExtension = _load_torch_extension_tools()
+    torch, _, Extension = _load_torch_extension_tools()
     if torch is None:
         message = (
             "PyTorch is unavailable, so rl_engine._C cannot be built. Install a matching "
@@ -116,6 +135,24 @@ def get_extensions():
     if os.environ.get("KERNEL_ALIGN_DEV_RPATH") == "1":
         torch_rpath.append(f"-Wl,-rpath,{torch_lib_dir}")
     is_rocm = getattr(torch.version, "hip", None) is not None
+
+    if _musa_build_available(torch):
+        extensions.append(
+            Extension(
+                name="rl_engine._C",
+                sources=[
+                    "csrc/musa/ops.cpp",
+                    "csrc/musa/fused_logp_kernel.mu",
+                ],
+                include_dirs=[],
+                extra_compile_args={
+                    "cxx": ["-O3", "-std=c++17", "-DKERNEL_ALIGN_WITH_MUSA"],
+                    "mcc": ["-O3", "-std=c++17", "-DKERNEL_ALIGN_WITH_MUSA"],
+                },
+                extra_link_args=list(torch_rpath),
+            )
+        )
+        return extensions
 
     # CUDAExtension is intentionally used for both CUDA and ROCm. On ROCm,
     # PyTorch's BuildExtension hipifies CUDA sources and invokes hipcc; it also
@@ -254,7 +291,7 @@ def get_extensions():
             nvcc_flags = _filter_rocm_incompatible_nvcc_flags(nvcc_flags)
 
         extensions.append(
-            CUDAExtension(
+            Extension(
                 name="rl_engine._C",
                 sources=cuda_sources,
                 include_dirs=[],

--- a/tests/test_musa_fused_logp.py
+++ b/tests/test_musa_fused_logp.py
@@ -10,22 +10,43 @@ def _musa_available() -> bool:
 
 
 @pytest.mark.skipif(not _musa_available(), reason="requires a MUSA device")
-def test_musa_fused_logp_matches_reference_and_supports_backward():
+@pytest.mark.parametrize(
+    ("dtype", "atol", "rtol"),
+    [
+        pytest.param(torch.float32, 1e-5, 1e-5, id="fp32"),
+        pytest.param(torch.float16, 2e-3, 2e-3, id="fp16"),
+        pytest.param(torch.bfloat16, 2e-2, 2e-2, id="bf16"),
+    ],
+)
+def test_musa_fused_logp_matches_reference_and_supports_backward(dtype, atol, rtol):
     from rl_engine import _C
 
     assert hasattr(_C, "fused_logp")
-    logits = torch.randn(4, 257, device="musa", dtype=torch.float32, requires_grad=True)
+    assert hasattr(_C, "fused_logp_backward")
+    logits = torch.randn(4, 257, device="musa", dtype=dtype, requires_grad=True)
     token_ids = torch.tensor([0, 17, 128, 256], device="musa", dtype=torch.long)
+    upstream = torch.tensor([0.25, -1.5, 2.0, 0.75], device="musa", dtype=dtype)
 
     output = FusedLogpGenericOp()(logits, token_ids)
-    reference = torch.log_softmax(logits.float(), dim=-1).gather(
-        1, token_ids[:, None]
-    ).squeeze(1)
-    assert torch.allclose(output, reference, atol=1e-5, rtol=1e-5)
+    reference = torch.log_softmax(logits.float(), dim=-1).gather(1, token_ids[:, None]).squeeze(1)
+    assert torch.allclose(output.float(), reference, atol=atol, rtol=rtol)
 
-    output.sum().backward()
+    output.backward(upstream)
     assert logits.grad is not None
     assert torch.isfinite(logits.grad).all()
+
+    reference_logits = logits.detach().float().requires_grad_(True)
+    reference_output = (
+        torch.log_softmax(reference_logits, dim=-1).gather(1, token_ids[:, None]).squeeze(1)
+    )
+    reference_output.backward(upstream.float())
+    assert reference_logits.grad is not None
+    assert torch.allclose(
+        logits.grad.float(),
+        reference_logits.grad.to(dtype).float(),
+        atol=atol,
+        rtol=rtol,
+    )
 
 
 @pytest.mark.skipif(not _musa_available(), reason="requires a MUSA device")

--- a/tests/test_musa_fused_logp.py
+++ b/tests/test_musa_fused_logp.py
@@ -1,0 +1,34 @@
+import pytest
+import torch
+
+from rl_engine.kernels.ops.cuda.loss.logp import FusedLogpGenericOp
+from rl_engine.kernels.registry import KernelRegistry
+
+
+def _musa_available() -> bool:
+    return hasattr(torch, "musa") and torch.musa.is_available()
+
+
+@pytest.mark.skipif(not _musa_available(), reason="requires a MUSA device")
+def test_musa_fused_logp_matches_reference_and_supports_backward():
+    from rl_engine import _C
+
+    assert hasattr(_C, "fused_logp")
+    logits = torch.randn(4, 257, device="musa", dtype=torch.float32, requires_grad=True)
+    token_ids = torch.tensor([0, 17, 128, 256], device="musa", dtype=torch.long)
+
+    output = FusedLogpGenericOp()(logits, token_ids)
+    reference = torch.log_softmax(logits.float(), dim=-1).gather(
+        1, token_ids[:, None]
+    ).squeeze(1)
+    assert torch.allclose(output, reference, atol=1e-5, rtol=1e-5)
+
+    output.sum().backward()
+    assert logits.grad is not None
+    assert torch.isfinite(logits.grad).all()
+
+
+@pytest.mark.skipif(not _musa_available(), reason="requires a MUSA device")
+def test_musa_registry_selects_fused_logp_backend():
+    backend = KernelRegistry().get_op("logp", device="musa")
+    assert backend.__class__.__name__ == "FusedLogpGenericOp"


### PR DESCRIPTION
# [MUSA][kernels] Add native MUSA fused_logp kernel

## Summary

Adds a native MUSA implementation for the generic `fused_logp` kernel.

The MUSA implementation computes selected-token log probabilities and their
input gradients directly from logits using row-wise fused max and sum-exp
reductions. It supports FP32, FP16, and BF16 inputs, preserves the existing
`FusedLogpGenericOp` autograd wrapper, and falls back to the existing PyTorch
implementation when the MUSA extension is unavailable.

| Path | Status |
| --- | --- |
| MUSA forward (`csrc/musa/fused_logp_kernel.mu`) | Row-wise fused max/sum-exp kernel. New. |
| MUSA backward (`csrc/musa/fused_logp_kernel.mu`) | Row-wise native gradient kernel that avoids materializing the full softmax. New. |
| MUSA extension binding (`csrc/musa/ops.cpp`) | Validated `fused_logp` and `fused_logp_backward` entry points. New. |
| Python dispatch | MUSA `logp` selects the fused backend through the kernel registry. New. |
| Backward | MUSA uses the native backward kernel; other platforms retain the existing autograd path. |
| CUDA / ROCm / CPU behavior | Preserved. |
| Tests | Added MUSA forward, backward, and registry coverage. |
| Benchmark | MUSA S5000 results collected using the same shapes as the official CUDA fused-logp benchmark. |

## Implementation

- Added `csrc/musa/fused_logp_kernel.mu`.
  - Uses one CTA per logits row.
  - Computes the row maximum and sum-exp in FP32.
  - Gathers the selected-token logit directly from the input row.
  - Computes `grad_output * (one_hot(target) - softmax(logits))` in the native backward kernel.
  - Recomputes row statistics in the backward pass without allocating an `[N, V]` probability tensor.
  - Supports FP32, FP16, and BF16 logits.
  - Returns the output in the input dtype.
- Added `csrc/musa/ops.cpp`.
  - Exposes the MUSA `fused_logp` and `fused_logp_backward` bindings.
  - Validates device, shape, dtype, token range, and row count.
  - Converts input tensors to contiguous storage before launching the kernel.
- Updated `setup.py`.
  - Detects an available MUSA build environment.
  - Uses `MUSAExtension` for MUSA builds.
  - Compiles only the MUSA fused-logp sources in the MUSA path.
  - Preserves the existing CUDA and ROCm extension paths.
- Updated `rl_engine/kernels/registry.py`.
  - Adds the `MUSA_FUSED_LOGP_GENERIC` backend.
  - Routes the MUSA `logp` operation to `FusedLogpGenericOp`.
  - Keeps indexed, online, and deterministic log-probability variants on their existing backends.
- Added `tests/test_musa_fused_logp.py`.
  - Verifies native extension symbol availability.
  - Checks forward results against `log_softmax + gather`.
- Verifies native backward execution and finite input gradients.
  - Confirms MUSA registry dispatch.

## Validation environment

| Item | Value |
| --- | --- |
| GPU | Moore Threads MTT S5000 |
| GPU count | 8 |
| Benchmark devices | 1 |
| MUSA runtime | 40305 |
| Driver | 3.3.5-server |
| PyTorch | 2.7.1 |
| torch_musa | 2.7.1+5f0ecd1 |
| Host compiler | mcc 5.2.0 |
| MUSA architecture | `mp_31` |
| Python | 3.10 |

## Correctness / Tests

### Build

```text
RL_KERNEL_REQUIRE_EXT=1 \
python3 -m pip install --no-build-isolation --no-deps -e .

Result: successfully built and installed RL-Kernel
```

### MUSA-specific tests

```text
python3 -m pytest tests/test_musa_fused_logp.py -q

Result: 2 passed
```

The MUSA-specific tests cover:

- Native `_C.fused_logp` symbol availability.
- Forward correctness against `log_softmax + gather`.
- Autograd backward execution.
- Finite input gradients.
- MUSA registry selection.

### Existing fused-logp accuracy tests

```text
python3 -m pytest tests/test_op_accuracy.py \
  -q -k "fused_logp"

Result: 8 passed, 7 skipped, 3 deselected
```

### Registry tests

```text
python3 -m pytest tests/test_kernel_registry.py -q

Result: 12 passed
```

## Benchmarks

Single MTT S5000, one GPU, FP16, 5 warmup iterations and 20 measured iterations. The native and reference implementations both run on the same MUSA device. The reference implementation uses `log_softmax + gather`.

The benchmark shapes match the official CUDA fused-logp benchmark:

- `batch=16`, `seq_len=512`, `vocab=128256`
- `batch=32`, `seq_len=512`, `vocab=128256`

### Forward

| Shape (`Batch x Seq x Vocab`) | Dtype | Native MUSA (ms) | PyTorch reference (ms) | Native / reference | Tokens/s | Native peak VRAM | Reference peak VRAM |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `16 x 512 x 128256` | `float16` | 9.303 | 14.669 | 1.58x faster | 880,583 | 1.96 GB | 9.79 GB |
| `32 x 512 x 128256` | `float16` | 18.036 | 29.439 | 1.63x faster | 908,415 | 3.91 GB | 19.57 GB |

The maximum absolute forward difference was `0` for both tested shapes after converting outputs to FP32 for comparison.

### Forward + Backward

The native path uses the MUSA `fused_logp` kernel for forward and the native MUSA `fused_logp_backward` kernel for backward.

| Shape (`Batch x Seq x Vocab`) | Dtype | Native fwd+bwd (ms) | PyTorch reference fwd+bwd (ms) | Native / reference | Native peak VRAM | Reference peak VRAM | Input grad max abs diff |
| --- | --- | ---: | ---: | ---: | ---: | ---: | ---: |
| `16 x 512 x 128256` | `float16` | 24.918 | 33.772 | 1.36x faster | 3.91 GB | 13.70 GB | 2.38e-7 |
| `32 x 512 x 128256` | `float16` | 48.811 | 67.729 | 1.39x faster | 7.83 GB | 27.40 GB | 4.77e-7 |

The native MUSA backward kernel removes the Python softmax materialization from the critical path. The end-to-end forward-plus-backward path is 1.36x faster for batch 16 and 1.39x faster for batch 32.

## Files

- `csrc/musa/fused_logp_kernel.mu`
- `csrc/musa/ops.cpp`
- `setup.py`
- `rl_engine/kernels/registry.py`
- `tests/test_musa_fused_logp.py`

## Limitations

- The native MUSA implementation covers the generic `fused_logp` forward and backward paths.
- Indexed, online, and deterministic log-probability variants continue to use their existing backends.
- The benchmark measures one MUSA S5000 device and should not be interpreted as a direct hardware comparison with the official H100 CUDA results.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added MUSA-accelerated fused log-probability calculations for selected tokens.
  - Added forward and backward gradient computation for floating-point, half-precision, and bfloat16 tensors.
  - MUSA devices now automatically select the optimized fused log-probability implementation.
  - Added MUSA build support for the extension.

- **Bug Fixes**
  - Added validation for device, shape, dtype, and token-index compatibility.

- **Tests**
  - Added coverage for MUSA outputs, gradients, and backend selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->